### PR TITLE
Allow specifying GPU used for quantisation, overriding hardcoded cuda:0

### DIFF
--- a/auto_gptq/modeling/_utils.py
+++ b/auto_gptq/modeling/_utils.py
@@ -193,8 +193,10 @@ def pack_model(
     use_cuda_fp16=True,
     desc_act=False,
     warmup_triton: bool = False,
+    cuda_GPU: int = 0,
     force_layer_back_to_cpu: bool = False
 ):
+    GPU = cuda_GPU == 0 and CUDA_0 or f'cuda:{cuda_GPU}'
     QuantLinear = dynamically_import_QuantLinear(use_triton=use_triton, desc_act=desc_act, group_size=group_size, bits=bits, disable_exllama=False, disable_exllamav2=True)
 
     if force_layer_back_to_cpu:
@@ -220,7 +222,7 @@ def pack_model(
         logger.warning(
             "using autotune_warmup will move model to GPU, make sure you have enough VRAM to load the whole model."
         )
-        QuantLinear.warmup(model.to(CUDA_0), seqlen=model.seqlen)
+        QuantLinear.warmup(model.to(GPU), seqlen=model.seqlen)
 
 
 def check_and_get_model_type(model_dir, trust_remote_code=False):


### PR DESCRIPTION
This simple change adds a new parameter to `model.quantize()`, called `cuda_GPU`. Defaulting to 0.

When specified, this overrides the hardcoded `cuda:0` which has been in the codebase since the dawn of time.

This will allow me to easily direct multiple GPTQ quantisations to separate GPUs on a multi-GPU system.

Until now I've achieved that by launching a separate script and setting `CUDA_VISIBLE_DEVICES=x` in the environment when calling that script.

But now I'd like to handle this with an `import` instead, for various reasons.  I initially tried using `CUDA_VISIBLE_DEVICES` in the module being imported, but I hit a scary PyTorch error when I try this (`RuntimeError: device >= 0 && device < num_gpus INTERNAL ASSERT FAILED at "../aten/src/ATen/cuda/CUDAContext.cpp":50, please report a bug to PyTorch. device=1, num_gpus=`)  EDIT: I've now solved that torch error!

I have cumulatively spent about 4 hours trying to debug and fix that, with no success.  Then I wondered how hard it'd be to change AutoGPTQ to take in the GPU param instead.. and that took 4 minutes 😢 😁 

Anyway, hope this simple change is good enough. There's probably better ways to do it, but this at least has to be better than hardcoding `CUDA_0` as has been the case forever.