### PR TITLE
Implemented cross-platform processor counting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ if BUILD_CUDA_EXT:
        
     if platform.system() != 'Windows':
         print("Generating qigen kernels...")
-        p = int(subprocess.run("cat /proc/cpuinfo | grep cores | head -1", shell=True, check=True, text=True, stdout=subprocess.PIPE).stdout.split(" ")[2])
+        p = int(subprocess.run(["grep", "-c", "^processor", "/proc/cpuinfo"], stdout=subprocess.PIPE, text=True).stdout.strip())
         try:
             subprocess.check_output(["python", "./autogptq_extension/qigen/generate.py", "--module", "--search", "--p", str(p)])
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
This is not a complete solution for aarm64 builds, but addresses the first element, revealing the next, related to x86_64-specific g++ flags when running `python ./autogptq_extension/qigen/generate.py --module --search --p 12` a componan of the build process. The resulting stacktrace follows:
```
g++: error: unrecognized command line option ‘-mavx’
g++: error: unrecognized command line option ‘-mfma’
g++: error: unrecognized command line option ‘-mavx2’
Traceback (most recent call last):
  File "./autogptq_extension/qigen/generate.py", line 1475, in <module>
    gen_module_search(args.r, args.p, [2,3,4])
  File "./autogptq_extension/qigen/generate.py", line 1418, in gen_module_search
    gen_and_compile(n,m,t,n,mb,tb,1,mu,tu,p,u,bits=bits, gs=gs, module=True)
  File "./autogptq_extension/qigen/generate.py", line 799, in gen_and_compile
    subprocess.check_output(["g++", "-O3", "-o", "./autogptq_extension/qigen/mmm", "./autogptq_extension/qigen/mmm.cpp", "-mavx", "-mfma", "-mavx2", "-ftree-vectorize", "-fno-signaling-nans", "-fno-trapping-math", "-march=native", "-fopenmp"])
  File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['g++', '-O3', '-o', './autogptq_extension/qigen/mmm', './autogptq_extension/qigen/mmm.cpp', '-mavx', '-mfma', '-mavx2', '-ftree-vectorize', '-fno-signaling-nans', '-fno-trapping-math', '-march=native', '-fopenmp']' returned non-zero exit status 1.
```
I have not yet identified suitable alternative flags.

It should be noted that this can b applied to `v0.5.0-release` and `main` branches as well