### PR TITLE
Change deci_lm model type to deci

### DIFF
--- a/auto_gptq/modeling/_const.py
+++ b/auto_gptq/modeling/_const.py
@@ -22,7 +22,7 @@ SUPPORTED_MODELS = [
     "internlm",
     "qwen",
     "xverse",
-    "deci_lm",
+    "deci",
     "stablelm_epoch",
 ]
 if compare_transformers_version("v4.28.0", op="ge"):

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -42,7 +42,7 @@ GPTQ_CAUSAL_LM_MODEL_MAP = {
     "mistral": MistralGPTQForCausalLM,
     "Yi": YiGPTQForCausalLM,
     "xverse": XverseGPTQForCausalLM,
-    "deci_lm": DeciLMGPTQForCausalLM,
+    "deci": DeciLMGPTQForCausalLM,
     "stablelm_epoch": StableLMEpochGPTQForCausalLM,
     "mixtral": MixtralGPTQForCausalLM,
 }


### PR DESCRIPTION
DeciLM (implemented in #481) added model_type to their config which changed the type from `deci_lm` to `deci`

This is just a simple fix to follow that naming.

Thanks @RajdeepBorgohain for bringing this to my attention.
https://github.com/PanQiWei/AutoGPTQ/commit/97ba340e46cc9920e678fe734f9b04ca8bf18357#r135555067

