### PR TITLE
updated marlin serialization

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -28,8 +28,10 @@ from ._utils import *
 from ._utils import unpack_awq, pack_from_tensors
 from ..nn_modules.qlinear import GeneralQuantLinear
 from ..nn_modules._fused_base import FusedBaseAttentionModule, FusedBaseMLPModule
-from ..nn_modules.qlinear.qlinear_marlin import _validate_marlin_compatibility
 from ..quantization import GPTQ
+from ..utils.marlin_utils import (
+    prepare_model_for_marlin_load, _validate_marlin_compatibility, 
+)
 from ..utils.data_utils import collate_data
 from ..utils.import_utils import (
     dynamically_import_QuantLinear, TRITON_AVAILABLE, AUTOGPTQ_CUDA_AVAILABLE, EXLLAMA_KERNELS_AVAILABLE, QIGEN_AVAILABLE, EXLLAMAV2_KERNELS_AVAILABLE
@@ -58,10 +60,11 @@ class BaseQuantizeConfig(PushToHubMixin):
     static_groups: bool = field(default=False)
     sym: bool = field(default=True)
     true_sequential: bool = field(default=True)
+    is_marlin_format: bool = field(default=False)
     model_name_or_path: Optional[str] = field(default=None)
     model_file_base_name: Optional[str] = field(default=None)
     awq_gemm_checkpoint: Optional[bool] = field(default=False)
-
+    
     def __post_init__(self):
         fields_info = fields(self)
 
@@ -148,6 +151,7 @@ class BaseQuantizeConfig(PushToHubMixin):
             "true_sequential": self.true_sequential,
             "model_name_or_path": self.model_name_or_path,
             "model_file_base_name": self.model_file_base_name,
+            "is_marlin_format": self.is_marlin_format,
         }
 
 
@@ -169,7 +173,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         is_triton_backend: bool = False,
         injected_fused_attention: bool = False,
         injected_fused_mlp: bool = False,
-        trainable: bool = False
+        trainable: bool = False,
+        is_marlin_format: bool = False,
     ):
         super().__init__()
 
@@ -183,6 +188,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         self.injected_fused_attention = injected_fused_attention
         self.injected_fused_mlp = injected_fused_mlp
         self.trainable = trainable
+        self.is_marlin_format = is_marlin_format
 
     @property
     def quantized(self):
@@ -603,11 +609,15 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             safetensors_metadata['gptq_group_size'] = str(self.quantize_config.group_size)
             safetensors_metadata['gptq_desc_act'] = str(self.quantize_config.desc_act)
             safetensors_metadata['gptq_damp_percent'] = str(self.quantize_config.damp_percent)
+            safetensors_metadata['gptq_is_marlin_format'] = str(self.is_marlin_format)
 
             safe_save(state_dict, join(save_dir, model_save_name), safetensors_metadata)
         else:
             model_save_name = model_base_name + ".bin"
             torch.save(self.model.state_dict(), join(save_dir, model_save_name))
+
+        # If model is marlin format, update config to enable reloading.
+        self.quantize_config.is_marlin_format = self.is_marlin_format
 
         self.model.config.save_pretrained(save_dir)
         self.quantize_config.save_pretrained(save_dir)
@@ -739,6 +749,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         trainable: bool = False,
         disable_exllama: Optional[bool] = None,
         disable_exllamav2: bool = False,
+        
         **kwargs
     ):
         """load quantized model from local disk"""
@@ -828,7 +839,14 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
 
         if quantize_config is None:
             quantize_config = BaseQuantizeConfig.from_pretrained(model_name_or_path, **cached_file_kwargs, **kwargs)
-        
+
+        if hasattr(quantize_config, "is_marlin_format") and quantize_config.is_marlin_format:
+            if not use_marlin:
+                raise ValueError(
+                    "You passed a GPTQ model saved in Marlin format but use_marlin=False. "
+                    "Pass use_marlin=True to utilize this model."
+                )
+
         if model_basename is None:
             if quantize_config.model_file_base_name:
                 possible_model_basenames = [quantize_config.model_file_base_name]
@@ -874,7 +892,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                         break
         
         quantize_config.model_file_base_name = true_model_basename
-        
+
+
         if resolved_archive_file is None:
             raise FileNotFoundError(f"Could not find a model in {model_name_or_path} with a name in {', '.join(searched_files)}. Please specify the argument model_basename to use a custom file name.")
                 
@@ -1060,13 +1079,14 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
 
             # TODO: Move this logic in a marlin_utils.py file.
             if use_marlin:
+                # Validate the model can run in Marlin.
                 if torch_dtype != torch.float16:
                     raise ValueError("Marlin kernel requires torch_dtype=torch.float16.")
-
                 unsupported_reason = _validate_marlin_compatibility(quantize_config)
                 if unsupported_reason is not None:
                     raise ValueError(f"The model {model_name_or_path} can not be converted to use the Marlin kernel for the following reason: {unsupported_reason}, which is not supported by Marlin kernel.")
 
+                # Load the quant linear type we need.
                 quant_linear_class = dynamically_import_QuantLinear(
                     use_triton=use_triton,
                     desc_act=quantize_config.desc_act,
@@ -1075,55 +1095,22 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                     disable_exllama=disable_exllama,
                     disable_exllamav2=disable_exllamav2
                 )
+                
+                # Prepare model for marlin load.
+                #   If stub is marlin serialzed         --> load from directly
+                #   If stub has cached marlin version   --> load from the cached versin
+                #   Otherwise                           --> convert to marlin, cache, load from cache
+                model, model_save_name = prepare_model_for_marlin_load(
+                    model_name_or_path=model_name_or_path, 
+                    model=model,
+                    quantize_config=quantize_config,
+                    quant_linear_class=quant_linear_class,
+                    torch_dtype=torch_dtype,
+                    current_model_save_name=model_save_name,
+                    device_map=device_map
+                )
 
-                if is_local:
-                    is_cached = os.path.isfile(os.path.join(model_name_or_path, "autogptq_model.safetensors"))
-                else:
-                    namespace, subfolder = model_name_or_path.split("/")
-                    assets_path = huggingface_hub.cached_assets_path(library_name="autogptq", namespace=namespace, subfolder=subfolder)
-                    weight_path = os.path.join(assets_path, "autogptq_model.safetensors")
-
-                    is_cached = os.path.isfile(weight_path)
-
-                if is_cached:
-                    if is_local:
-                        model_save_name = os.path.join(model_name_or_path, "autogptq_model.safetensors")
-                    else:
-                        namespace, subfolder = model_name_or_path.split("/")
-                        assets_path = huggingface_hub.cached_assets_path(library_name="autogptq", namespace=namespace, subfolder=subfolder)
-                        model_save_name = os.path.join(assets_path, "autogptq_model.safetensors")
-
-                    logger.info(f"Loading a GPTQ model, detected a cached repacked weight for Marlin kernel at {model_save_name}.")
-
-                    # We will use the cached checkpoint to load parameters and buffers in the model, so we only need to replace QuantLinear layers here.
-                    model = convert_to_marlin(model, quant_linear_class, quantize_config, repack=False)
-                else:
-                    # Loading the GPTQ checkpoint to do the conversion.
-                    # TODO: Avoid loading the model with wrong QuantLinear, and directly use
-                    # Marlin ones. The repacking can be done directly on the safetensors, just
-                    # as for AWQ checkpoints.
-                    accelerate.utils.modeling.load_checkpoint_in_model(
-                        model,
-                        dtype=torch_dtype,  # This is very hacky but works due to https://github.com/huggingface/accelerate/blob/bd72a5f1a80d5146554458823f8aeda0a9db5297/src/accelerate/utils/modeling.py#L292
-                        checkpoint=model_save_name,
-                        device_map=device_map,
-                        offload_state_dict=True,
-                        offload_buffers=True
-                    )
-
-                    model = convert_to_marlin(model, quant_linear_class, quantize_config, repack=True)
-
-                    # Cache the converted model.
-                    if is_local:
-                        model_save_name = os.path.join(model_name_or_path, "autogptq_model.safetensors")
-                        safe_save(model.state_dict(), model_save_name)
-                    else:
-                        namespace, subfolder = model_name_or_path.split("/")
-                        assets_path = huggingface_hub.cached_assets_path(library_name="autogptq", namespace=namespace, subfolder=subfolder)
-                        model_save_name = os.path.join(assets_path, "autogptq_model.safetensors")
-
-                        safe_save(model.state_dict(), model_save_name)
-
+                # Disable incompatible optimizations.
                 if inject_fused_attention or inject_fused_mlp:
                     # TODO: Validate whether that can be used.
                     logger.info("Disabling fused attention and mlp injection because Marlin kernel is used")
@@ -1249,7 +1236,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             is_triton_backend=use_triton,
             injected_fused_attention=inject_fused_attention,
             injected_fused_mlp=inject_fused_mlp and use_triton,
-            trainable=trainable
+            trainable=trainable,
+            is_marlin_format=use_marlin,
         )
 
     def warmup_triton(self, enabled: bool = True):

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -64,7 +64,7 @@ class BaseQuantizeConfig(PushToHubMixin):
     model_name_or_path: Optional[str] = field(default=None)
     model_file_base_name: Optional[str] = field(default=None)
     awq_gemm_checkpoint: Optional[bool] = field(default=False)
-    
+
     def __post_init__(self):
         fields_info = fields(self)
 

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -743,7 +743,6 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         trainable: bool = False,
         disable_exllama: Optional[bool] = None,
         disable_exllamav2: bool = False,
-        
         **kwargs
     ):
         """load quantized model from local disk"""

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -64,7 +64,6 @@ class BaseQuantizeConfig(PushToHubMixin):
     model_name_or_path: Optional[str] = field(default=None)
     model_file_base_name: Optional[str] = field(default=None)
     awq_gemm_checkpoint: Optional[bool] = field(default=False)
-    
     def __post_init__(self):
         fields_info = fields(self)
 

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -1232,7 +1232,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             is_triton_backend=use_triton,
             injected_fused_attention=inject_fused_attention,
             injected_fused_mlp=inject_fused_mlp and use_triton,
-            trainable=trainable,
+            trainable=trainable
         )
 
     def warmup_triton(self, enabled: bool = True):

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -173,7 +173,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         is_triton_backend: bool = False,
         injected_fused_attention: bool = False,
         injected_fused_mlp: bool = False,
-        trainable: bool = False,
+        trainable: bool = False
     ):
         super().__init__()
 

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -64,6 +64,7 @@ class BaseQuantizeConfig(PushToHubMixin):
     model_name_or_path: Optional[str] = field(default=None)
     model_file_base_name: Optional[str] = field(default=None)
     awq_gemm_checkpoint: Optional[bool] = field(default=False)
+    
     def __post_init__(self):
         fields_info = fields(self)
 

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -891,8 +891,6 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                         break
         
         quantize_config.model_file_base_name = true_model_basename
-
-
         if resolved_archive_file is None:
             raise FileNotFoundError(f"Could not find a model in {model_name_or_path} with a name in {', '.join(searched_files)}. Please specify the argument model_basename to use a custom file name.")
                 

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -823,7 +823,6 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 "You have activated both exllama and exllamav2 kernel. Setting disable_exllama to True and keeping disable_exllamav2 to False"
             )
             disable_exllama = True
-
                     
         # == step1: prepare configs and file names == #
         config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **cached_file_kwargs)

--- a/auto_gptq/modeling/_utils.py
+++ b/auto_gptq/modeling/_utils.py
@@ -121,79 +121,6 @@ def make_quant(
             use_qigen=use_qigen
         )
 
-@torch.no_grad()
-def convert_to_marlin(model, model_quantlinear, quantization_config, repack: bool):
-    """
-    Converts GPTQ-packed weights to the Marlin format. This assumes that the model already meets Marlin kernel constraints.
-
-    Arguments:
-        repack (`bool`):
-            Whether to repack the qweights from `model` into the Marlin's QuantLinear layers.
-    """
-    if repack:
-        message = "Repacking weights to be compatible with Marlin kernel..."
-    else:
-        message = "Overriding QuantLinear layers to use Marlin's QuantLinear..."
-
-    for name, module in tqdm(model.named_modules(), desc=message, total=len(list(model.named_modules()))):
-        if not isinstance(module, model_quantlinear):
-            continue
-
-        if module.bias is not None and torch.count_nonzero(module.bias) > 0:
-            bias = module.bias
-        else:
-            bias = None
-
-        parent_name = ".".join(name.split(".")[:-1])
-        layer_name = name[len(parent_name) + 1:]
-
-        # Dequantize the weight.
-        if repack:
-            dequantized_weight, dequantized_qzeros = dequantize_weight(module)
-            dequantized_weight = dequantized_weight.to(torch.float16)
-
-            if not torch.all(dequantized_qzeros == 8):
-                raise ValueError(f"Marlin kernel is compatible only with checkpoints using symetric quantization. Found non-symmetric quantization for the weight {name}.")
-
-            linear_module = nn.Linear(
-                in_features=dequantized_weight.shape[1],
-                out_features=dequantized_weight.shape[0],
-                bias=bias is not None,
-                dtype=torch.float16,
-                device="cuda"
-            )
-            linear_module.weight.data.copy_(dequantized_weight)
-
-            if bias is not None:
-                linear_module.bias.data.copy_(bias)
-        else:
-            linear_module = nn.Linear(module.infeatures, module.outfeatures, bias=bias is not None, dtype=torch.float16, device="cuda")
-
-        # Create new linear method and copy to model.
-        new_module = MarlinQuantLinear(
-            bits=4,
-            group_size=module.group_size,
-            infeatures=linear_module.in_features,
-            outfeatures=linear_module.out_features,
-            bias=bias is not None,
-            trainable=False,
-        )
-
-        if repack:
-            new_module.pack(linear_module, scales=copy.deepcopy(module.scales.data.t()).to("cuda"))
-
-        # Save to parent.
-        parent_module = model.get_submodule(parent_name)
-        setattr(parent_module, layer_name, new_module)
-
-        # Free cuda memory.
-        del module
-        if repack:
-            del dequantized_weight
-        torch.cuda.empty_cache()
-        gc.collect()
-    return model
-
 def preprocess_checkpoint_qigen(
     module,
     names,
@@ -648,5 +575,4 @@ __all__ = [
     "check_and_get_model_type",
     "simple_dispatch_model",
     "make_sure_no_tensor_in_meta_device",
-    "convert_to_marlin",
 ]

--- a/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
@@ -166,19 +166,6 @@ class QuantLinear(nn.Module):
         C = C + self.bias if self.bias is not None else C 
         return C
 
-
-# Adapted from https://github.com/rib-2/marlin/tree/conversion
-def _validate_marlin_compatibility(quantization_config):
-    if quantization_config.bits != 4:
-        return f"The quantized model uses a bitwidth different than 4 (found {quantization_config.bits})"
-    if quantization_config.group_size != 128 and quantization_config.group_size != -1:
-        return f"The quantized model uses a group size that is not 128 or -1 (found quantization_config.group_size)"
-    if not quantization_config.sym:
-        return f"The quantized model uses asymmetric quantization"
-    if quantization_config.desc_act:
-        return f"The quantized model uses act-order (also called desc-act) scheme"
-    return None
-
 # Copied from https://github.com/IST-DASLab/marlin/pull/1
 @torch.no_grad()
 def unpack_4bit_to_32bit_signed(qweight, qzeros):

--- a/auto_gptq/utils/marlin_utils.py
+++ b/auto_gptq/utils/marlin_utils.py
@@ -140,7 +140,9 @@ def convert_to_marlin(model, model_quantlinear, quantization_config, repack: boo
             dequantized_weight = dequantized_weight.to(torch.float16)
 
             if not torch.all(dequantized_qzeros == 8):
-                raise ValueError(f"Marlin kernel is compatible only with checkpoints using symetric quantization. Found non-symmetric quantization for the weight {name}.")
+                raise ValueError(
+                    f"Marlin kernel is compatible only with checkpoints using symetric quantization. "
+                     "Found non-symmetric quantization for the weight {name}.")
 
             linear_module = torch.nn.Linear(
                 in_features=dequantized_weight.shape[1],
@@ -153,9 +155,6 @@ def convert_to_marlin(model, model_quantlinear, quantization_config, repack: boo
 
             if bias is not None:
                 linear_module.bias.data.copy_(bias)
-
-            in_features = linear_module.in_features
-            out_features = linear_module.out_features
         else:
             linear_module = torch.nn.Linear(
                 in_features=module.infeatures, 

--- a/auto_gptq/utils/marlin_utils.py
+++ b/auto_gptq/utils/marlin_utils.py
@@ -1,0 +1,193 @@
+import torch
+import huggingface_hub
+import accelerate
+import torch
+from safetensors.torch import save_file as safe_save
+from ..nn_modules.qlinear.qlinear_marlin import QuantLinear as MarlinQuantLinear
+from ..nn_modules.qlinear.qlinear_marlin import dequantize_weight
+
+import gc, os, copy
+from logging import getLogger
+from tqdm import tqdm
+
+logger = getLogger(__name__)
+
+def prepare_model_for_marlin_load(
+    model_name_or_path, 
+    model,
+    quantize_config,
+    quant_linear_class,
+    torch_dtype,
+    current_model_save_name,
+    device_map
+):  
+     # If GPTQ model is serialized in the Marlin format, load directly (no repacking).
+    if is_marlin_serialized(quantize_config):
+        model_save_name = current_model_save_name
+        logger.info(f"Loading a GPTQ model, detected Marlin serialized format at {model_save_name}.")
+        model = convert_to_marlin(model, quant_linear_class, quantize_config, repack=False)
+
+    # If GPTQ model has Marlin version cached locally, load from the cached version (no repacking).
+    elif is_marlin_cached(model_name_or_path):
+        model_save_name = _get_cached_marlin_save_name(model_name_or_path)
+        logger.info(f"Loading a GPTQ model, detected a cached repacked weight for Marlin kernel at {model_save_name}.")
+        model = convert_to_marlin(model, quant_linear_class, quantize_config, repack=False)
+    
+    # Otherwise, convert the model to Marlin format first and cache locally.
+    else:
+        # Loading the GPTQ checkpoint to do the conversion.
+        # TODO: Avoid loading the model with wrong QuantLinear, and directly use
+        # Marlin ones. The repacking can be done directly on the safetensors, just
+        # as for AWQ checkpoints.
+        model_save_name = current_model_save_name
+        accelerate.utils.modeling.load_checkpoint_in_model(
+            model,
+            dtype=torch_dtype,  # This is very hacky but works due to https://github.com/huggingface/accelerate/blob/bd72a5f1a80d5146554458823f8aeda0a9db5297/src/accelerate/utils/modeling.py#L292
+            checkpoint=model_save_name,
+            device_map=device_map,
+            offload_state_dict=True,
+            offload_buffers=True
+        )
+        # Convert model to marlin, repacking weights into Marlin format.
+        model = convert_to_marlin(model, quant_linear_class, quantize_config, repack=True)
+        
+        # Cache the converted model.
+        model_save_name = cache_marlin(model, model_name_or_path)
+
+    return model, model_save_name
+
+# Gets The Cached Weight Path.
+#   -- if remote:   $HF_HOME/assets/autogptq/{model_path}/autogptq_model.safetensors
+#   -- if local:    {path}/autogptq_model.safetensors
+def _get_cached_marlin_save_name(model_name_or_path):
+    if os.path.isdir(model_name_or_path):
+        return os.path.join(model_name_or_path, "autogptq_model.safetensors")
+    else:
+        namespace, subfolder = model_name_or_path.split("/")
+        assets_path = huggingface_hub.cached_assets_path(library_name="autogptq", namespace=namespace, subfolder=subfolder)
+        return os.path.join(assets_path, "autogptq_model.safetensors")
+
+# Gets The Serialized Path.
+#   -- if remote:   $HF_HOME/hub/models--
+#   -- if local:    {path}
+def _get_serialized_marlin_save_name(model_name_or_path):
+    if os.path.isdir(model_name_or_path):
+        return model_name_or_path
+    else:
+        namespace, subfolder = model_name_or_path.split("/")
+        return huggingface_hub.cached_assets_path(library_name="hub", namespace=namespace, subfolder=subfolder) 
+
+# Checks if a model stub is a marlin serialized model.
+def is_marlin_serialized(quantize_config):
+    if not hasattr(quantize_config, "is_marlin_format"):
+        return False
+    return quantize_config.is_marlin_format
+
+# Checks if a model stub has a cached marlin version:
+#   -- if remote:   $HF_HOME/assets/autogptq/{model_stub}.
+#   -- if local:    {path}/autogptq_model.safetensors
+def is_marlin_cached(model_name_or_path):
+    model_save_name = _get_cached_marlin_save_name(model_name_or_path)
+    return os.path.isfile(model_save_name)
+
+# Caches Marlin model by saving autogptq_model.safetensors to
+#   -- if remote:   $HF_HOME/assets/autogptq/{model_stub}.
+#   -- if local:    {path}/autogptq_model.safetensors 
+def cache_marlin(model, model_name_or_path):
+    model_save_name = _get_cached_marlin_save_name(model_name_or_path)
+    safe_save(model.state_dict(), model_save_name)
+    return model_save_name
+
+# Adapted from https://github.com/rib-2/marlin/tree/conversion
+def _validate_marlin_compatibility(quantization_config):
+    if quantization_config.bits != 4:
+        return f"The quantized model uses a bitwidth different than 4 (found {quantization_config.bits})"
+    if quantization_config.group_size != 128 and quantization_config.group_size != -1:
+        return f"The quantized model uses a group size that is not 128 or -1 (found quantization_config.group_size)"
+    if not quantization_config.sym:
+        return f"The quantized model uses asymmetric quantization"
+    if quantization_config.desc_act:
+        return f"The quantized model uses act-order (also called desc-act) scheme"
+    return None
+
+@torch.no_grad()
+def convert_to_marlin(model, model_quantlinear, quantization_config, repack: bool):
+    """
+    Converts GPTQ-packed weights to the Marlin format. This assumes that the model already meets Marlin kernel constraints.
+
+    Arguments:
+        repack (`bool`):
+            Whether to repack the qweights from `model` into the Marlin's QuantLinear layers.
+    """
+    if repack:
+        message = "Repacking weights to be compatible with Marlin kernel..."
+    else:
+        message = "Overriding QuantLinear layers to use Marlin's QuantLinear..."
+
+    for name, module in tqdm(model.named_modules(), desc=message, total=len(list(model.named_modules()))):
+        if not isinstance(module, model_quantlinear):
+            continue
+
+        if module.bias is not None and torch.count_nonzero(module.bias) > 0:
+            bias = module.bias
+        else:
+            bias = None
+
+        parent_name = ".".join(name.split(".")[:-1])
+        layer_name = name[len(parent_name) + 1:]
+
+        # Dequantize the weight.
+        if repack:
+            dequantized_weight, dequantized_qzeros = dequantize_weight(module)
+            dequantized_weight = dequantized_weight.to(torch.float16)
+
+            if not torch.all(dequantized_qzeros == 8):
+                raise ValueError(f"Marlin kernel is compatible only with checkpoints using symetric quantization. Found non-symmetric quantization for the weight {name}.")
+
+            linear_module = torch.nn.Linear(
+                in_features=dequantized_weight.shape[1],
+                out_features=dequantized_weight.shape[0],
+                bias=bias is not None,
+                dtype=torch.float16,
+                device="cuda"
+            )
+            linear_module.weight.data.copy_(dequantized_weight)
+
+            if bias is not None:
+                linear_module.bias.data.copy_(bias)
+
+            in_features = linear_module.in_features
+            out_features = linear_module.out_features
+        else:
+            linear_module = torch.nn.Linear(
+                in_features=module.infeatures, 
+                out_features=module.outfeatures, 
+                bias=bias is not None, 
+                dtype=torch.float16, 
+                device="cuda"
+            )
+
+        # Create new linear method and copy to model.
+        new_module = MarlinQuantLinear(
+            bits=4,
+            group_size=module.group_size,
+            infeatures=linear_module.in_features,
+            outfeatures=linear_module.out_features,
+            bias=bias is not None,
+            trainable=False,
+        )
+
+        if repack:
+            new_module.pack(linear_module, scales=copy.deepcopy(module.scales.data.t()).to("cuda"))
+
+        # Save to parent.
+        parent_module = model.get_submodule(parent_name)
+        setattr(parent_module, layer_name, new_module)
+
+        # Free cuda memory.
+        del module
+        if repack:
+            del dequantized_weight
+        torch.cuda.empty_cache()
+        gc.collect()
+    return model

--- a/auto_gptq/utils/marlin_utils.py
+++ b/auto_gptq/utils/marlin_utils.py
@@ -53,7 +53,7 @@ def prepare_model_for_marlin_load(
         
         # Cache the converted model.
         model_save_name = cache_marlin(model, model_name_or_path)
-
+    
     return model, model_save_name
 
 # Gets The Cached Weight Path.
@@ -180,4 +180,8 @@ def convert_to_marlin(model, model_quantlinear, quantization_config, repack: boo
             del dequantized_weight
         torch.cuda.empty_cache()
         gc.collect()
+    
+
+    # Set quantization config to be Marlin.
+    quantization_config.is_marlin_format = True
     return model

--- a/auto_gptq/utils/marlin_utils.py
+++ b/auto_gptq/utils/marlin_utils.py
@@ -88,6 +88,14 @@ def cache_marlin(model, model_name_or_path):
     safe_save(model.state_dict(), model_save_name)
     return model_save_name
 
+# Validate marlin suppor
+def _validate_marlin_device_support():
+    device_capacity = torch.cuda.get_device_capability()
+    return (
+        device_capacity[0] == 8 and 
+        (device_capacity[1] == 0 or device_capacity[1] == 6)
+    )
+
 # Adapted from https://github.com/rib-2/marlin/tree/conversion
 def _validate_marlin_compatibility(quantization_config):
     if quantization_config.bits != 4:
@@ -184,4 +192,8 @@ def convert_to_marlin(model, model_quantlinear, quantization_config, repack: boo
 
     # Set quantization config to be Marlin.
     quantization_config.is_marlin_format = True
+    if hasattr(model.config, "quantization_config"):
+        model.config.quantization_config["is_marlin_format"] = True
+    else:
+        raise ValueError("No quantization config found.")
     return model

--- a/auto_gptq/utils/marlin_utils.py
+++ b/auto_gptq/utils/marlin_utils.py
@@ -67,16 +67,6 @@ def _get_cached_marlin_save_name(model_name_or_path):
         assets_path = huggingface_hub.cached_assets_path(library_name="autogptq", namespace=namespace, subfolder=subfolder)
         return os.path.join(assets_path, "autogptq_model.safetensors")
 
-# Gets The Serialized Path.
-#   -- if remote:   $HF_HOME/hub/models--
-#   -- if local:    {path}
-def _get_serialized_marlin_save_name(model_name_or_path):
-    if os.path.isdir(model_name_or_path):
-        return model_name_or_path
-    else:
-        namespace, subfolder = model_name_or_path.split("/")
-        return huggingface_hub.cached_assets_path(library_name="hub", namespace=namespace, subfolder=subfolder) 
-
 # Checks if a model stub is a marlin serialized model.
 def is_marlin_serialized(quantize_config):
     if not hasattr(quantize_config, "is_marlin_format"):

--- a/tests/test_q4.py
+++ b/tests/test_q4.py
@@ -581,10 +581,10 @@ class TestQ4Marlin(unittest.TestCase):
         device = torch.device("cuda:0")
 
         model_id = "TheBloke/Llama-2-7B-Chat-GPTQ"
-        model_q = AutoGPTQForCausalLM.from_quantized(model_id, device="cuda:0", use_triton=False, inject_fused_attention=False, inject_fused_mlp=False, disable_exllama=True, disable_exllamav2=True, use_marlin=True)
+        model_q = AutoGPTQForCausalLM.from_quantized(model_id, device="cuda:0", use_marlin=True)
 
         has_marlin = False
-        for name, module in model_q.named_modules():
+        for _, module in model_q.named_modules():
             if isinstance(module, MarlinQuantLinear):
                 has_marlin = True
                 break

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,64 @@
+import unittest
+from auto_gptq import AutoGPTQForCausalLM
+import tempfile
+import os
+import json
+import time
+from auto_gptq.utils.marlin_utils import _get_cached_marlin_save_name
+import huggingface_hub
+
+class TestSerialization(unittest.TestCase):
+    MODEL_ID = "habanoz/TinyLlama-1.1B-Chat-v0.3-GPTQ"
+
+    def setUp(self):
+        namespace, subfolder = self.MODEL_ID.split("/")
+        assets_path = huggingface_hub.cached_assets_path(library_name="auto_gptq", namespace=namespace, subfolder=subfolder)
+        cached_model_path = os.path.join(assets_path, "autogptq_model.safetensors")
+
+        if os.path.isfile(cached_model_path):
+            os.remove(cached_model_path)
+
+    def test_marlin_local_serialization(self):
+        start = time.time()
+        model = AutoGPTQForCausalLM.from_quantized(self.MODEL_ID, device="cuda:0", use_marlin=True)
+        end = time.time()
+
+        first_load_time = end - start
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model.save_pretrained(tmpdir)
+        
+            self.assertTrue(os.path.isfile(os.path.join(tmpdir, "model.safetensors")))
+            self.assertFalse(os.path.isfile(os.path.join(tmpdir, "autogptq_model.safetensors")))
+
+            with open(os.path.join(tmpdir, "quantize_config.json"), "r") as config_file:  
+                config = json.load(config_file)
+
+            self.assertTrue(config["is_marlin_format"])
+
+            start = time.time()
+            model = AutoGPTQForCausalLM.from_quantized(tmpdir, device="cuda:0", use_marlin=True)
+            end = time.time()
+
+            second_load_time = end - start
+
+        self.assertTrue(second_load_time < 0.2 * first_load_time)
+
+    def test_marlin_hf_cache_serialization(self):
+        start = time.time()
+        model = AutoGPTQForCausalLM.from_quantized(self.MODEL_ID, device="cuda:0", use_marlin=True)
+        end = time.time()
+
+        first_load_time = end - start
+
+        model_cache_path = _get_cached_marlin_save_name(self.MODEL_ID)
+        self.assertTrue("assets" in model_cache_path)
+        self.assertTrue(os.path.isfile(model_cache_path))
+
+        start = time.time()
+        model = AutoGPTQForCausalLM.from_quantized(self.MODEL_ID, device="cuda:0", use_marlin=True)
+        end = time.time()
+
+        second_load_time = end - start
+
+        self.assertTrue(second_load_time < 0.2 * first_load_time)


### PR DESCRIPTION
PR does a couple things:

- moves the repacking logic to `marlin_utils.py`
- supports saving the model with `is_marlin_format` in the gptq config, such that during reload we can load directly
- implements reloading a marlin_serialized model

I introduced some terminology:
- `is_marlin_serialized` --> in this case, the stub / local path actually has a marlin model saved
- `is_marlin_cached` --> in this case, there is a cached marlin model available in `assets`
- else --> in this case, we need to repack the model

Testing:
```bash
import gc
import torch
from transformers import AutoTokenizer
from auto_gptq import AutoGPTQForCausalLM

model_id = "TheBloke/Llama-2-7B-Chat-GPTQ"
tokenizer = AutoTokenizer.from_pretrained(model_id)

def generate(model):
    inputs = tok("Hello my name is", return_tensors="pt")
    inputs = {k: inputs[k].to("cuda") for k in inputs}
    outputs = model.generate(**inputs, max_new_tokens=50)
    print(tok.batch_decode(outputs)[0])

# load model for the first time from hf hub (empty_cache)
model = AutoGPTQForCausalLM.from_quantized(model_id, use_marlin=True)
generate(model) # << coherent
save_path = "/network/rshaw/saved_marlin_model"
model.save_pretrained(save_path)

del model
torch.cuda.empty_cache()
gc.collect()

# load model from cache
model = AutoGPTQForCausalLM.from_quantized(model_id, use_marlin=True)
generate(model) # << coherent

del model
torch.cuda.empty_cache()
gc.collect()

# load_from_disk
model = AutoGPTQForCausalLM.from_quantized(save_path, use_marlin=True)
generate(model) # << coherent
```