### PR TITLE
Tritonv2: faster `triton` dequant kernel and refactored `QuantLinear`

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -1,45 +1,57 @@
 import copy
 import json
-import warnings
-import os
-from dataclasses import dataclass, field, fields
 import logging
-from os.path import join, isfile, isdir
+import os
+import tempfile
+import warnings
+from dataclasses import dataclass, field, fields
+from os.path import isdir, isfile, join
 from typing import Dict, List, Optional, Union
-from packaging import version
+
 import accelerate
+import huggingface_hub
 import torch
 import torch.nn as nn
 import transformers
 from accelerate.hooks import remove_hook_from_module
-from safetensors.torch import save_file as safe_save
-from safetensors.torch import load_file as safe_load
+from packaging import version
 from safetensors import safe_open
+from safetensors.torch import load_file as safe_load
+from safetensors.torch import save_file as safe_save
+from tqdm import tqdm
 from transformers import AutoConfig, AutoModelForCausalLM, PreTrainedModel
-from transformers.utils.hub import PushToHubMixin, cached_file, create_repo, create_commit, CommitOperationAdd
-from transformers.utils.generic import ContextManagers
 from transformers.modeling_utils import no_init_weights
-import tempfile
+from transformers.utils.generic import ContextManagers
+from transformers.utils.hub import (
+    CommitOperationAdd,
+    PushToHubMixin,
+    cached_file,
+    create_commit,
+    create_repo,
+)
 
-# TODO: Remove those star imports.
-from ._const import *
-from ._utils import *
-
-from ._utils import unpack_awq, pack_from_tensors
-from ..nn_modules.qlinear import GeneralQuantLinear
 from ..nn_modules._fused_base import FusedBaseAttentionModule, FusedBaseMLPModule
+from ..nn_modules.qlinear import GeneralQuantLinear
 from ..nn_modules.qlinear.qlinear_marlin import _validate_marlin_compatibility
 from ..quantization import GPTQ
 from ..utils.data_utils import collate_data
 from ..utils.import_utils import (
-    dynamically_import_QuantLinear, TRITON_AVAILABLE, AUTOGPTQ_CUDA_AVAILABLE, EXLLAMA_KERNELS_AVAILABLE, QIGEN_AVAILABLE, EXLLAMAV2_KERNELS_AVAILABLE
+    AUTOGPTQ_CUDA_AVAILABLE,
+    EXLLAMA_KERNELS_AVAILABLE,
+    EXLLAMAV2_KERNELS_AVAILABLE,
+    QIGEN_AVAILABLE,
+    TRITON_AVAILABLE,
+    dynamically_import_QuantLinear,
 )
-from tqdm import tqdm
-import huggingface_hub
+
+# TODO: Remove those star imports.
+from ._const import *
+from ._utils import *
+from ._utils import pack_from_tensors, unpack_awq
 
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
-formatter = logging.Formatter('%(levelname)s - %(message)s')
+formatter = logging.Formatter("%(levelname)s - %(message)s")
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
@@ -48,6 +60,7 @@ SYNONYMS = {
     "w_bit": "bits",
     "q_group_size": "group_size",
 }
+
 
 @dataclass
 class BaseQuantizeConfig(PushToHubMixin):
@@ -66,7 +79,9 @@ class BaseQuantizeConfig(PushToHubMixin):
         fields_info = fields(self)
 
         if self.bits not in fields_info[0].metadata["choices"]:
-            raise ValueError(f"only support quantize to {fields_info[0].metadata['choices']} bits.")
+            raise ValueError(
+                f"only support quantize to {fields_info[0].metadata['choices']} bits."
+            )
         if self.group_size != -1 and self.group_size <= 0:
             raise ValueError("unless equal to -1, group_size must greater then 0.")
         if not (0 < self.damp_percent < 1):
@@ -92,7 +107,7 @@ class BaseQuantizeConfig(PushToHubMixin):
         for quantize_config_filename in ["quantize_config.json", "quant_config.json"]:
             if os.path.isdir(save_dir):  # Local
                 resolved_config_file = join(save_dir, quantize_config_filename)
-            else: # Remote
+            else:  # Remote
                 resolved_config_file = cached_file(
                     save_dir,
                     quantize_config_filename,
@@ -112,8 +127,10 @@ class BaseQuantizeConfig(PushToHubMixin):
                 break
 
         if resolved_config_file is None:
-            raise ValueError("No quantize_config.json or quant_config.json file was found in the model repository.")
-        
+            raise ValueError(
+                "No quantize_config.json or quant_config.json file was found in the model repository."
+            )
+
         field_names = [field.name for field in fields(cls)]
         with open(resolved_config_file, "r", encoding="utf-8") as f:
             args_from_json = json.load(f)
@@ -126,14 +143,18 @@ class BaseQuantizeConfig(PushToHubMixin):
                 elif key in SYNONYMS and SYNONYMS[key] in field_names:
                     filtered_args[SYNONYMS[key]] = val
                 else:
-                    logger.warning(f"ignoring unknown parameter in {quantize_config_filename}: {key}.")
-            
+                    logger.warning(
+                        f"ignoring unknown parameter in {quantize_config_filename}: {key}."
+                    )
+
             if filtered_args["awq_gemm_checkpoint"]:
                 # AWQ does not reorder the rows.
                 filtered_args["desc_act"] = False
 
             if "sym" not in args_from_json:
-                logger.warning(f"The quantization configuration {quantize_config_filename} does not contain an entry `sym` (symetric quantization). This may result in silent errors.")
+                logger.warning(
+                    f"The quantization configuration {quantize_config_filename} does not contain an entry `sym` (symetric quantization). This may result in silent errors."
+                )
 
             return cls(**filtered_args)
 
@@ -169,7 +190,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         is_triton_backend: bool = False,
         injected_fused_attention: bool = False,
         injected_fused_mlp: bool = False,
-        trainable: bool = False
+        trainable: bool = False,
     ):
         super().__init__()
 
@@ -218,14 +239,18 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             else:
                 labels = copy.deepcopy(input_ids)
             new_examples.append(
-                {"input_ids": input_ids, "attention_mask": attention_mask, "labels": labels}
+                {
+                    "input_ids": input_ids,
+                    "attention_mask": attention_mask,
+                    "labels": labels,
+                }
             )
         pad_token_id = self.config.pad_token_id
         if not pad_token_id:
             pad_token_id = self.config.eos_token_id
 
         new_examples = [
-            collate_data(new_examples[start: start + batch_size], pad_token_id)
+            collate_data(new_examples[start : start + batch_size], pad_token_id)
             for start in range(0, len(new_examples), batch_size)
         ]
         for new_example in new_examples:
@@ -241,10 +266,12 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         use_triton: bool = False,
         use_cuda_fp16: bool = True,
         autotune_warmup_after_quantized: bool = False,
-        cache_examples_on_gpu: bool = True
+        cache_examples_on_gpu: bool = True,
     ):
         if self.quantized:
-            raise EnvironmentError("can't execute quantize because the model is quantized.")
+            raise EnvironmentError(
+                "can't execute quantize because the model is quantized."
+            )
         if use_triton and not TRITON_AVAILABLE:
             logger.warning("triton is not installed, reset use_triton to False")
             use_triton = False
@@ -283,23 +310,30 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 self.data_device = device if cache_examples_on_gpu else CPU
 
             def forward(self, inp=None, **kwargs):
-                if inp is None:  # some models use all key-value arguments in forward pass call
+                if (
+                    inp is None
+                ):  # some models use all key-value arguments in forward pass call
                     for kwarg_name in ["hidden_states"]:
                         if kwarg_name in kwargs:
                             inp = kwargs[kwarg_name]
                             break
                 layer_inputs.append(move_to_device(inp, self.data_device))
-                
+
                 if kwargs["attention_mask"] is not None:
-                    attention_masks.append(kwargs["attention_mask"].to(self.data_device))
+                    attention_masks.append(
+                        kwargs["attention_mask"].to(self.data_device)
+                    )
                 else:
                     attention_masks.append(None)
-                
+
                 pos_ids = kwargs.get("position_ids", None)
                 if pos_ids is not None:
                     position_ids.append(move_to_device(pos_ids, self.data_device))
                 one_kwargs = dict()
-                for k, v in kwargs.items():  # make sure other arguments also be captured
+                for (
+                    k,
+                    v,
+                ) in kwargs.items():  # make sure other arguments also be captured
                     if k not in ["hidden_states", "attention_mask", "position_ids"]:
                         one_kwargs[k] = nested_move_to_device(v, self.data_device)
                 layer_input_kwargs.append(one_kwargs)
@@ -386,53 +420,75 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                     handles.append(subset[name].register_forward_hook(add_batch(name)))
                 for j in range(num_batches):
                     layer_input = move_to_device(layer_inputs[j], cur_layer_device)
-                    layer_attention_mask = move_to_device(attention_masks[j], cur_layer_device)
-                    additional_layer_inputs = {
-                        "attention_mask": layer_attention_mask
-                    }
-                    layer_position_ids = None if not position_ids else move_to_device(position_ids[j], cur_layer_device)
+                    layer_attention_mask = move_to_device(
+                        attention_masks[j], cur_layer_device
+                    )
+                    additional_layer_inputs = {"attention_mask": layer_attention_mask}
+                    layer_position_ids = (
+                        None
+                        if not position_ids
+                        else move_to_device(position_ids[j], cur_layer_device)
+                    )
                     if layer_position_ids is not None:
                         additional_layer_inputs["position_ids"] = layer_position_ids
                     for k, v in layer_input_kwargs[j].items():
-                        additional_layer_inputs[k] = nested_move_to_device(v, cur_layer_device)
+                        additional_layer_inputs[k] = nested_move_to_device(
+                            v, cur_layer_device
+                        )
                     layer(layer_input, **additional_layer_inputs)
                 for h in handles:
                     h.remove()
 
                 for name in subset:
-                    logger.info(f'Quantizing {name} in layer {i + 1}/{len(layers)}...')
+                    logger.info(f"Quantizing {name} in layer {i + 1}/{len(layers)}...")
                     scale, zero, g_idx = gptq[name].fasterquant(
                         percdamp=self.quantize_config.damp_percent,
                         group_size=self.quantize_config.group_size,
                         actorder=self.quantize_config.desc_act,
-                        static_groups=self.quantize_config.static_groups
+                        static_groups=self.quantize_config.static_groups,
                     )
-                    quantizers[f'{self.layers_block_name}.{i}.{name}'] = (
-                        gptq[name].quantizer.to(CPU if force_layer_back_to_cpu else cur_layer_device),
-                        move_to_device(scale, CPU if force_layer_back_to_cpu else cur_layer_device),
-                        move_to_device(zero, CPU if force_layer_back_to_cpu else cur_layer_device),
-                        move_to_device(g_idx, CPU if force_layer_back_to_cpu else cur_layer_device)
+                    quantizers[f"{self.layers_block_name}.{i}.{name}"] = (
+                        gptq[name].quantizer.to(
+                            CPU if force_layer_back_to_cpu else cur_layer_device
+                        ),
+                        move_to_device(
+                            scale, CPU if force_layer_back_to_cpu else cur_layer_device
+                        ),
+                        move_to_device(
+                            zero, CPU if force_layer_back_to_cpu else cur_layer_device
+                        ),
+                        move_to_device(
+                            g_idx, CPU if force_layer_back_to_cpu else cur_layer_device
+                        ),
                     )
                     gptq[name].free()
 
             for j in range(num_batches):
                 layer_input = move_to_device(layer_inputs[j], cur_layer_device)
-                layer_attention_mask = move_to_device(attention_masks[j], cur_layer_device)
-                additional_layer_inputs = {
-                    "attention_mask": layer_attention_mask
-                }
-                layer_position_ids = None if not position_ids else move_to_device(position_ids[j], cur_layer_device)
+                layer_attention_mask = move_to_device(
+                    attention_masks[j], cur_layer_device
+                )
+                additional_layer_inputs = {"attention_mask": layer_attention_mask}
+                layer_position_ids = (
+                    None
+                    if not position_ids
+                    else move_to_device(position_ids[j], cur_layer_device)
+                )
                 if layer_position_ids is not None:
                     additional_layer_inputs["position_ids"] = layer_position_ids
                 for k, v in layer_input_kwargs[j].items():
-                    additional_layer_inputs[k] = nested_move_to_device(v, cur_layer_device)
+                    additional_layer_inputs[k] = nested_move_to_device(
+                        v, cur_layer_device
+                    )
                 layer_output = move_to_device(
                     layer(layer_input, **additional_layer_inputs)[0],
-                    cur_layer_device if cache_examples_on_gpu else CPU
+                    cur_layer_device if cache_examples_on_gpu else CPU,
                 )
                 layer_outputs.append(layer_output)
 
-            layers[i] = move_to_device(layer, CPU if force_layer_back_to_cpu else cur_layer_device)
+            layers[i] = move_to_device(
+                layer, CPU if force_layer_back_to_cpu else cur_layer_device
+            )
             del layer
             del gptq
             del layer_inputs
@@ -448,7 +504,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             use_cuda_fp16=use_cuda_fp16,
             desc_act=self.quantize_config.desc_act,
             warmup_triton=autotune_warmup_after_quantized,
-            force_layer_back_to_cpu=force_layer_back_to_cpu
+            force_layer_back_to_cpu=force_layer_back_to_cpu,
         )
         if device_map:
             self.model = remove_hook_from_module(self.model, recurse=True)
@@ -464,7 +520,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         if not self.hf_device_map:
             return self.model.device
         else:
-            device = [d for d in self.hf_device_map.values() if d not in {'disk'}][0]
+            device = [d for d in self.hf_device_map.values() if d not in {"disk"}][0]
             return torch.device(device)
 
     def to(self, device: Union[str, torch.device]):
@@ -526,15 +582,24 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             create_pr (`bool`, *optional*, defaults to `False`):
                 Whether or not to create a PR with the uploaded files or directly commit.
         """
-        if (self.quantize_config.model_name_or_path is None or not isdir(self.quantize_config.model_name_or_path)) and save_dir is None:
-            raise ValueError("Quantized model should be saved first, or you can provide save_dir to make sure model is saved to local disk before uploading.")
-        
+        if (
+            self.quantize_config.model_name_or_path is None
+            or not isdir(self.quantize_config.model_name_or_path)
+        ) and save_dir is None:
+            raise ValueError(
+                "Quantized model should be saved first, or you can provide save_dir to make sure model is saved to local disk before uploading."
+            )
+
         if save_dir is not None:
             logger.info(f"Saving model to {save_dir}")
             self.save_quantized(save_dir, use_safetensors, safetensors_metadata)
 
         repo_url = create_repo(
-            repo_id=repo_id, token=token, private=private, exist_ok=True, repo_type="model"
+            repo_id=repo_id,
+            token=token,
+            private=private,
+            exist_ok=True,
+            repo_type="model",
         )
         repo_id = repo_url.repo_id
 
@@ -544,7 +609,9 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 CommitOperationAdd(path_or_fileobj=join(work_dir, f), path_in_repo=f)
                 for f in os.listdir(work_dir)
             ]
-            logger.info(f"Uploading the following files to {repo_id}: {','.join(os.listdir(work_dir))}")
+            logger.info(
+                f"Uploading the following files to {repo_id}: {','.join(os.listdir(work_dir))}"
+            )
             return create_commit(
                 repo_id=repo_id,
                 operations=operations,
@@ -554,16 +621,26 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 repo_type="model",
             )
 
-    def save_quantized(self, save_dir: str, use_safetensors: bool = True, safetensors_metadata: Optional[Dict[str, str]] = None):
+    def save_quantized(
+        self,
+        save_dir: str,
+        use_safetensors: bool = True,
+        safetensors_metadata: Optional[Dict[str, str]] = None,
+    ):
         """save quantized model and configs to local disk"""
         os.makedirs(save_dir, exist_ok=True)
 
         if not self.quantized:
-            raise EnvironmentError("can only save quantized model, please execute .quantize first.")
+            raise EnvironmentError(
+                "can only save quantized model, please execute .quantize first."
+            )
 
         self.model.to(CPU)
 
-        model_base_name = self.quantize_config.model_file_base_name or f"gptq_model-{self.quantize_config.bits}bit-{self.quantize_config.group_size}g"
+        model_base_name = (
+            self.quantize_config.model_file_base_name
+            or f"gptq_model-{self.quantize_config.bits}bit-{self.quantize_config.group_size}g"
+        )
         if use_safetensors:
             model_save_name = model_base_name + ".safetensors"
             state_dict = self.model.state_dict()
@@ -583,25 +660,36 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                             new_key = str(key)
                             new_value = str(value)
                         except Exception as e:
-                            raise TypeError(f"safetensors_metadata: both keys and values must be strings and an error occured when trying to convert them: {e}")
+                            raise TypeError(
+                                f"safetensors_metadata: both keys and values must be strings and an error occured when trying to convert them: {e}"
+                            )
                         if new_key in new_safetensors_metadata:
-                            logger.warning(f"After converting safetensors_metadata keys to strings, the key '{new_key}' is duplicated. Ensure that all your metadata keys are strings to avoid overwriting.")
+                            logger.warning(
+                                f"After converting safetensors_metadata keys to strings, the key '{new_key}' is duplicated. Ensure that all your metadata keys are strings to avoid overwriting."
+                            )
                         new_safetensors_metadata[new_key] = new_value
                 safetensors_metadata = new_safetensors_metadata
                 if converted_keys:
-                    logger.debug(f"One or more safetensors_metadata keys or values had to be converted to str(). Final safetensors_metadata: {safetensors_metadata}")
+                    logger.debug(
+                        f"One or more safetensors_metadata keys or values had to be converted to str(). Final safetensors_metadata: {safetensors_metadata}"
+                    )
 
             # Format is required to enable Accelerate to load the metadata
             # otherwise it raises an OSError
-            safetensors_metadata['format'] = "pt"
+            safetensors_metadata["format"] = "pt"
 
             # Store the quantization configuration as safetensors metadata
             from auto_gptq import __version__
-            safetensors_metadata['auto_gptq_version'] = str(__version__)
-            safetensors_metadata['gptq_bits'] = str(self.quantize_config.bits)
-            safetensors_metadata['gptq_group_size'] = str(self.quantize_config.group_size)
-            safetensors_metadata['gptq_desc_act'] = str(self.quantize_config.desc_act)
-            safetensors_metadata['gptq_damp_percent'] = str(self.quantize_config.damp_percent)
+
+            safetensors_metadata["auto_gptq_version"] = str(__version__)
+            safetensors_metadata["gptq_bits"] = str(self.quantize_config.bits)
+            safetensors_metadata["gptq_group_size"] = str(
+                self.quantize_config.group_size
+            )
+            safetensors_metadata["gptq_desc_act"] = str(self.quantize_config.desc_act)
+            safetensors_metadata["gptq_damp_percent"] = str(
+                self.quantize_config.damp_percent
+            )
 
             safe_save(state_dict, join(save_dir, model_save_name), safetensors_metadata)
         else:
@@ -613,9 +701,17 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         self.quantize_config.model_name_or_path = save_dir
         self.quantize_config.model_file_base_name = model_base_name
 
-    def save_pretrained(self, save_dir: str, use_safetensors: bool = True, safetensors_metadata: Optional[Dict[str, str]] = None, **kwargs):
+    def save_pretrained(
+        self,
+        save_dir: str,
+        use_safetensors: bool = True,
+        safetensors_metadata: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
         """alias of save_quantized"""
-        logger.warning("you are using save_pretrained, which will re-direct to save_quantized.")
+        logger.warning(
+            "you are using save_pretrained, which will re-direct to save_quantized."
+        )
         self.save_quantized(save_dir, use_safetensors, safetensors_metadata)
 
     @classmethod
@@ -626,12 +722,14 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         max_memory: Optional[dict] = None,
         trust_remote_code: bool = False,
         torch_dtype: torch.dtype = torch.float16,
-        **model_init_kwargs
+        **model_init_kwargs,
     ):
         """load un-quantized pretrained model to cpu"""
 
         if not torch.cuda.is_available():
-            raise EnvironmentError("Load pretrained model to do quantization requires CUDA available.")
+            raise EnvironmentError(
+                "Load pretrained model to do quantization requires CUDA available."
+            )
 
         def skip(*args, **kwargs):
             pass
@@ -662,7 +760,9 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             "subfolder": subfolder,
         }
 
-        config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True, **cached_file_kwargs)
+        config = AutoConfig.from_pretrained(
+            pretrained_model_name_or_path, trust_remote_code=True, **cached_file_kwargs
+        )
         if config.model_type not in SUPPORTED_MODELS:
             raise TypeError(f"{config.model_type} isn't supported yet.")
 
@@ -681,13 +781,13 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 max_memory=max_memory,
                 no_split_module_classes=[cls.layer_type],
                 dtype=model_init_kwargs["torch_dtype"],
-                low_zero=False
+                low_zero=False,
             )
             model_init_kwargs["device_map"] = accelerate.infer_auto_device_map(
                 model,
                 max_memory=max_memory,
                 no_split_module_classes=[cls.layer_type],
-                dtype=model_init_kwargs["torch_dtype"]
+                dtype=model_init_kwargs["torch_dtype"],
             )
             model_init_kwargs["low_cpu_mem_usage"] = True
 
@@ -699,7 +799,9 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         torch.cuda.empty_cache()
 
         merged_kwargs = {**model_init_kwargs, **cached_file_kwargs}
-        model = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path, **merged_kwargs)
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path, **merged_kwargs
+        )
 
         model_config = model.config.to_dict()
         seq_len_keys = ["max_position_embeddings", "seq_length", "n_positions"]
@@ -709,7 +811,9 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                     model.seqlen = model_config[key]
                     break
         else:
-            logger.warning("can't get model's sequence length from model config, will set to 4096.")
+            logger.warning(
+                "can't get model's sequence length from model config, will set to 4096."
+            )
             model.seqlen = 4096
         model.eval()
 
@@ -738,7 +842,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         trainable: bool = False,
         disable_exllama: Optional[bool] = None,
         disable_exllamav2: bool = False,
-        **kwargs
+        **kwargs,
     ):
         """load quantized model from local disk"""
 
@@ -759,7 +863,13 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         revision = kwargs.pop("revision", None)
         subfolder = kwargs.pop("subfolder", "")
         commit_hash = kwargs.pop("_commit_hash", None)
+        use_tritonv2 = kwargs.pop("use_tritonv2", False)
 
+        if use_triton and use_tritonv2:
+            logging.warn(
+                "Both use_triton and use_tritonv2 are set to True. Defaulting to use_triton"
+            )
+            use_tritonv2 = False
         cached_file_kwargs = {
             "cache_dir": cache_dir,
             "force_download": force_download,
@@ -774,10 +884,11 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         }
         if use_qigen and not QIGEN_AVAILABLE:
             logger.warning("Qigen is not installed, reset use_qigen to False.")
-            use_qigen = False    
-        if use_triton and not TRITON_AVAILABLE:
+            use_qigen = False
+        if (use_triton or use_tritonv2) and not TRITON_AVAILABLE:
             logger.warning("Triton is not installed, reset use_triton to False.")
             use_triton = False
+            use_tritonv2 = False
         if not disable_exllama and not EXLLAMA_KERNELS_AVAILABLE:
             logger.warning(
                 "Exllama kernel is not installed, reset disable_exllama to True. "
@@ -804,7 +915,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 "2. You are using pytorch without CUDA support.\n"
                 "3. CUDA and nvcc are not installed in your device."
             )
-            
+
         if use_qigen and QIGEN_AVAILABLE:
             logger.warning("QIgen is active. Ignores all settings related to cuda.")
             inject_fused_attention = False
@@ -812,32 +923,41 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             use_triton = False
             disable_exllama = True
             disable_exllamav2 = True
-            
+
         if not disable_exllamav2 and not disable_exllama:
             logger.warning(
                 "You have activated both exllama and exllamav2 kernel. Setting disable_exllama to True and keeping disable_exllamav2 to False"
             )
             disable_exllama = True
-                    
+
         # == step1: prepare configs and file names == #
-        config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code, **cached_file_kwargs)
+        config = AutoConfig.from_pretrained(
+            model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            **cached_file_kwargs,
+        )
 
         if config.model_type not in SUPPORTED_MODELS:
             raise TypeError(f"{config.model_type} isn't supported yet.")
 
         if quantize_config is None:
-            quantize_config = BaseQuantizeConfig.from_pretrained(model_name_or_path, **cached_file_kwargs, **kwargs)
-        
+            quantize_config = BaseQuantizeConfig.from_pretrained(
+                model_name_or_path, **cached_file_kwargs, **kwargs
+            )
+
         if model_basename is None:
             if quantize_config.model_file_base_name:
                 possible_model_basenames = [quantize_config.model_file_base_name]
             else:
-                possible_model_basenames = [f"gptq_model-{quantize_config.bits}bit-{quantize_config.group_size}g", "model"]
+                possible_model_basenames = [
+                    f"gptq_model-{quantize_config.bits}bit-{quantize_config.group_size}g",
+                    "model",
+                ]
         else:
             possible_model_basenames = [model_basename]
-        
+
         quantize_config.model_name_or_path = model_name_or_path
-        
+
         extensions = []
         if use_safetensors:
             extensions.append(".safetensors")
@@ -863,7 +983,11 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             temp = None
             for ext in extensions:
                 for possible_model_basename in possible_model_basenames:
-                    resolved_archive_file = cached_file(model_name_or_path, possible_model_basename + ext, **cached_file_kwargs)
+                    resolved_archive_file = cached_file(
+                        model_name_or_path,
+                        possible_model_basename + ext,
+                        **cached_file_kwargs,
+                    )
                     if resolved_archive_file is None:
                         resolved_archive_file = temp
                     searched_files.append(possible_model_basename + ext)
@@ -871,36 +995,44 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                         temp = resolved_archive_file
                         true_model_basename = possible_model_basename
                         break
-        
+
         quantize_config.model_file_base_name = true_model_basename
-        
+
         if resolved_archive_file is None:
-            raise FileNotFoundError(f"Could not find a model in {model_name_or_path} with a name in {', '.join(searched_files)}. Please specify the argument model_basename to use a custom file name.")
-                
+            raise FileNotFoundError(
+                f"Could not find a model in {model_name_or_path} with a name in {', '.join(searched_files)}. Please specify the argument model_basename to use a custom file name."
+            )
+
         model_save_name = resolved_archive_file
 
         if (not disable_exllama or not disable_exllamav2) and trainable:
-            logger.warning("QuantLinear with the exllama backend not does support the trainable mode yet, switching to cuda/cuda_old/triton backend.")
+            logger.warning(
+                "QuantLinear with the exllama backend not does support the trainable mode yet, switching to cuda/cuda_old/triton backend."
+            )
             disable_exllama = True
             disable_exllamav2 = True
-            
-        elif not use_triton and trainable:
-            logger.warning("QuantLinear with cuda backend not support trainable mode yet, Switch to the pytorch backend.")
+
+        elif not (use_triton or use_tritonv2) and trainable:
+            logger.warning(
+                "QuantLinear with cuda backend not support trainable mode yet, Switch to the pytorch backend."
+            )
 
         # == step2: convert model to gptq-model (replace Linear with QuantLinear) == #
         def skip(*args, **kwargs):
             pass
-            
+
         if torch_dtype is None:
             if not use_qigen:
                 torch_dtype = torch.float16
             else:
                 torch_dtype = torch.float32
-        
+
         if torch_dtype != torch.float16:
-            logger.warning("Overriding use_cuda_fp16 to False since torch_dtype is not torch.float16.")
+            logger.warning(
+                "Overriding use_cuda_fp16 to False since torch_dtype is not torch.float16."
+            )
             use_cuda_fp16 = False
-        
+
         if not use_qigen:
             torch.nn.init.kaiming_uniform_ = skip
             torch.nn.init.uniform_ = skip
@@ -910,19 +1042,30 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
 
             init_contexts = [no_init_weights()]
             if low_cpu_mem_usage:
-                init_contexts.append(accelerate.init_empty_weights(include_buffers=False))
+                init_contexts.append(
+                    accelerate.init_empty_weights(include_buffers=False)
+                )
 
             with ContextManagers(init_contexts):
                 model = AutoModelForCausalLM.from_config(
-                    config,
-                    trust_remote_code=trust_remote_code,
-                    torch_dtype=torch_dtype
+                    config, trust_remote_code=trust_remote_code, torch_dtype=torch_dtype
                 )
 
                 layers = find_layers(model)
                 ignore_layers = [cls.lm_head_name] + cls.outside_layer_modules
                 for name in list(layers.keys()):
-                    if any([name.startswith(ignore_layer) for ignore_layer in ignore_layers]) or all([not name.endswith(ignore_layer) for sublist in cls.inside_layer_modules for ignore_layer in sublist]):
+                    if any(
+                        [
+                            name.startswith(ignore_layer)
+                            for ignore_layer in ignore_layers
+                        ]
+                    ) or all(
+                        [
+                            not name.endswith(ignore_layer)
+                            for sublist in cls.inside_layer_modules
+                            for ignore_layer in sublist
+                        ]
+                    ):
                         logger.info(f"The layer {name} is not quantized.")
                         del layers[name]
 
@@ -936,12 +1079,17 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                     disable_exllamav2=disable_exllamav2,
                     use_cuda_fp16=use_cuda_fp16,
                     desc_act=quantize_config.desc_act,
-                    trainable=trainable
+                    trainable=trainable,
                 )
                 model.tie_weights()
 
             # == step3: load checkpoint and dispatch == #
-            if isinstance(device_map, str) and device_map not in ["auto", "balanced", "balanced_low_0", "sequential"]:
+            if isinstance(device_map, str) and device_map not in [
+                "auto",
+                "balanced",
+                "balanced_low_0",
+                "sequential",
+            ]:
                 raise ValueError(
                     "If passing a string for `device_map`, please choose 'auto', 'balanced', 'balanced_low_0' or "
                     "'sequential'."
@@ -954,71 +1102,111 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 if device is not None:
                     device = torch.device(device)
                     if not max_memory and not device_map:
-                        device_map = {"": device.index if device.type == "cuda" else device.type}
+                        device_map = {
+                            "": device.index if device.type == "cuda" else device.type
+                        }
                 if not isinstance(device_map, dict) and device_map != "sequential":
                     max_memory = accelerate.utils.get_balanced_memory(
                         model=model,
                         max_memory=max_memory,
                         no_split_module_classes=[cls.layer_type],
-                        low_zero=(device_map == "balanced_low_0")
+                        low_zero=(device_map == "balanced_low_0"),
                     )
             if not isinstance(device_map, dict):
                 device_map = accelerate.infer_auto_device_map(
                     model,
                     max_memory=max_memory,
-                    no_split_module_classes=[cls.layer_type]
+                    no_split_module_classes=[cls.layer_type],
                 )
 
             if low_cpu_mem_usage:
-                make_sure_no_tensor_in_meta_device(model, use_triton, quantize_config.desc_act, quantize_config.group_size, bits=quantize_config.bits)
+                make_sure_no_tensor_in_meta_device(
+                    model,
+                    use_triton,
+                    quantize_config.desc_act,
+                    quantize_config.group_size,
+                    bits=quantize_config.bits,
+                )
 
             # TODO: move this logic in an awq_utils.py file.
             if quantize_config.awq_gemm_checkpoint:
                 if use_marlin:
-                    raise ValueError("Tried to load an AWQ kernel with use_marlin=True. This is currently not supported. Please open an issue in AutoGPTQ repository.")
+                    raise ValueError(
+                        "Tried to load an AWQ kernel with use_marlin=True. This is currently not supported. Please open an issue in AutoGPTQ repository."
+                    )
 
                 if is_local:
-                    is_cached = os.path.isfile(os.path.join(model_name_or_path, "autogptq_model.safetensors"))
+                    is_cached = os.path.isfile(
+                        os.path.join(model_name_or_path, "autogptq_model.safetensors")
+                    )
                 else:
                     namespace, subfolder = model_name_or_path.split("/")
-                    assets_path = huggingface_hub.cached_assets_path(library_name="autogptq", namespace=namespace, subfolder=subfolder)
-                    weight_path = os.path.join(assets_path, "autogptq_model.safetensors")
+                    assets_path = huggingface_hub.cached_assets_path(
+                        library_name="autogptq",
+                        namespace=namespace,
+                        subfolder=subfolder,
+                    )
+                    weight_path = os.path.join(
+                        assets_path, "autogptq_model.safetensors"
+                    )
 
                     is_cached = os.path.isfile(weight_path)
 
                 if is_cached:
                     if is_local:
-                        model_save_name = os.path.join(model_name_or_path, "autogptq_model.safetensors")
+                        model_save_name = os.path.join(
+                            model_name_or_path, "autogptq_model.safetensors"
+                        )
                     else:
                         namespace, subfolder = model_name_or_path.split("/")
-                        assets_path = huggingface_hub.cached_assets_path(library_name="autogptq", namespace=namespace, subfolder=subfolder)
-                        model_save_name = os.path.join(assets_path, "autogptq_model.safetensors")
+                        assets_path = huggingface_hub.cached_assets_path(
+                            library_name="autogptq",
+                            namespace=namespace,
+                            subfolder=subfolder,
+                        )
+                        model_save_name = os.path.join(
+                            assets_path, "autogptq_model.safetensors"
+                        )
 
-                    logger.info(f"Loading an AWQ model, detected a cached repacked weight at {model_save_name}.")
+                    logger.info(
+                        f"Loading an AWQ model, detected a cached repacked weight at {model_save_name}."
+                    )
                 else:
-                    logger.info("Loading an AWQ model. This requires repacking the weights, and no repacking cached weight was found. Grab a coffee!")
+                    logger.info(
+                        "Loading an AWQ model. This requires repacking the weights, and no repacking cached weight was found. Grab a coffee!"
+                    )
 
                     if "safetensors" not in model_save_name:
-                        raise NotImplementedError(f"Conversion from AWQ checkpoints is implemented only for safetensors checkpoints, found {model_save_name}")
+                        raise NotImplementedError(
+                            f"Conversion from AWQ checkpoints is implemented only for safetensors checkpoints, found {model_save_name}"
+                        )
                     if quantize_config.bits != 4:
-                        raise NotImplementedError(f"Conversion from AWQ checkpoints is supported only for 4 bits models. Found {quantize_config.bits} bits.")
+                        raise NotImplementedError(
+                            f"Conversion from AWQ checkpoints is supported only for 4 bits models. Found {quantize_config.bits} bits."
+                        )
                     gptq_layers = set()
                     non_gptq_params = set()
                     with safe_open(model_save_name, framework="pt") as f:
                         state_dict_keys = list(f.keys())
                         for state_dict_key in f.keys():
-                            if "qweight" not in state_dict_key and "qzeros" not in state_dict_key and "scales" not in state_dict_key:
+                            if (
+                                "qweight" not in state_dict_key
+                                and "qzeros" not in state_dict_key
+                                and "scales" not in state_dict_key
+                            ):
                                 non_gptq_params.add(state_dict_key)
                                 continue
-                            
+
                             # e.g. prefix "model.layers.3.self_attn.k_proj"
-                            prefix, _ = state_dict_key.rsplit('.', 1)
+                            prefix, _ = state_dict_key.rsplit(".", 1)
                             gptq_layers.add(prefix)
 
                         new_state_dict = {}
 
                         for state_dict_key in non_gptq_params:
-                            new_state_dict[state_dict_key] = f.get_tensor(state_dict_key)
+                            new_state_dict[state_dict_key] = f.get_tensor(
+                                state_dict_key
+                            )
 
                         gptq_layers = sorted(gptq_layers)
                         max_layer_name_length = len(max(gptq_layers, key=len))
@@ -1034,13 +1222,25 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                             awq_scales = f.get_tensor(gptq_layer_name + ".scales")
 
                             # TODO: add FAST unpacking.
-                            unpacked_qweight, unpacked_qzeros = unpack_awq(awq_qweight, awq_qzeros, awq_scales, bits=quantize_config.bits, group_size=quantize_config.group_size)
+                            unpacked_qweight, unpacked_qzeros = unpack_awq(
+                                awq_qweight,
+                                awq_qzeros,
+                                awq_scales,
+                                bits=quantize_config.bits,
+                                group_size=quantize_config.group_size,
+                            )
 
                             # TODO: add FAST repacking, this is too slow.
                             desc = f"Repacking {gptq_layer_name}..."
                             desc = desc + " " * (max_layer_name_length + 12 - len(desc))
                             pbar.set_description(desc)
-                            gptq_qweight, gptq_qzeros = pack_from_tensors(unpacked_qweight, unpacked_qzeros, awq_scales, bits=quantize_config.bits, group_size=quantize_config.group_size)
+                            gptq_qweight, gptq_qzeros = pack_from_tensors(
+                                unpacked_qweight,
+                                unpacked_qzeros,
+                                awq_scales,
+                                bits=quantize_config.bits,
+                                group_size=quantize_config.group_size,
+                            )
 
                             new_state_dict[gptq_layer_name + ".qweight"] = gptq_qweight
                             new_state_dict[gptq_layer_name + ".qzeros"] = gptq_qzeros
@@ -1048,23 +1248,35 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
 
                     # Cache the converted model.
                     if is_local:
-                        model_save_name = os.path.join(model_name_or_path, "autogptq_model.safetensors")
+                        model_save_name = os.path.join(
+                            model_name_or_path, "autogptq_model.safetensors"
+                        )
                         safe_save(new_state_dict, model_save_name)
                     else:
                         namespace, subfolder = model_name_or_path.split("/")
-                        assets_path = huggingface_hub.cached_assets_path(library_name="autogptq", namespace=namespace, subfolder=subfolder)
-                        model_save_name = os.path.join(assets_path, "autogptq_model.safetensors")
+                        assets_path = huggingface_hub.cached_assets_path(
+                            library_name="autogptq",
+                            namespace=namespace,
+                            subfolder=subfolder,
+                        )
+                        model_save_name = os.path.join(
+                            assets_path, "autogptq_model.safetensors"
+                        )
 
                         safe_save(new_state_dict, model_save_name)
 
             # TODO: Move this logic in a marlin_utils.py file.
             if use_marlin:
                 if torch_dtype != torch.float16:
-                    raise ValueError("Marlin kernel requires torch_dtype=torch.float16.")
+                    raise ValueError(
+                        "Marlin kernel requires torch_dtype=torch.float16."
+                    )
 
                 unsupported_reason = _validate_marlin_compatibility(quantize_config)
                 if unsupported_reason is not None:
-                    raise ValueError(f"The model {model_name_or_path} can not be converted to use the Marlin kernel for the following reason: {unsupported_reason}, which is not supported by Marlin kernel.")
+                    raise ValueError(
+                        f"The model {model_name_or_path} can not be converted to use the Marlin kernel for the following reason: {unsupported_reason}, which is not supported by Marlin kernel."
+                    )
 
                 quant_linear_class = dynamically_import_QuantLinear(
                     use_triton=use_triton,
@@ -1072,30 +1284,50 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                     group_size=quantize_config.group_size,
                     bits=quantize_config.bits,
                     disable_exllama=disable_exllama,
-                    disable_exllamav2=disable_exllamav2
+                    disable_exllamav2=disable_exllamav2,
                 )
 
                 if is_local:
-                    is_cached = os.path.isfile(os.path.join(model_name_or_path, "autogptq_model.safetensors"))
+                    is_cached = os.path.isfile(
+                        os.path.join(model_name_or_path, "autogptq_model.safetensors")
+                    )
                 else:
                     namespace, subfolder = model_name_or_path.split("/")
-                    assets_path = huggingface_hub.cached_assets_path(library_name="autogptq", namespace=namespace, subfolder=subfolder)
-                    weight_path = os.path.join(assets_path, "autogptq_model.safetensors")
+                    assets_path = huggingface_hub.cached_assets_path(
+                        library_name="autogptq",
+                        namespace=namespace,
+                        subfolder=subfolder,
+                    )
+                    weight_path = os.path.join(
+                        assets_path, "autogptq_model.safetensors"
+                    )
 
                     is_cached = os.path.isfile(weight_path)
 
                 if is_cached:
                     if is_local:
-                        model_save_name = os.path.join(model_name_or_path, "autogptq_model.safetensors")
+                        model_save_name = os.path.join(
+                            model_name_or_path, "autogptq_model.safetensors"
+                        )
                     else:
                         namespace, subfolder = model_name_or_path.split("/")
-                        assets_path = huggingface_hub.cached_assets_path(library_name="autogptq", namespace=namespace, subfolder=subfolder)
-                        model_save_name = os.path.join(assets_path, "autogptq_model.safetensors")
+                        assets_path = huggingface_hub.cached_assets_path(
+                            library_name="autogptq",
+                            namespace=namespace,
+                            subfolder=subfolder,
+                        )
+                        model_save_name = os.path.join(
+                            assets_path, "autogptq_model.safetensors"
+                        )
 
-                    logger.info(f"Loading a GPTQ model, detected a cached repacked weight for Marlin kernel at {model_save_name}.")
+                    logger.info(
+                        f"Loading a GPTQ model, detected a cached repacked weight for Marlin kernel at {model_save_name}."
+                    )
 
                     # We will use the cached checkpoint to load parameters and buffers in the model, so we only need to replace QuantLinear layers here.
-                    model = convert_to_marlin(model, quant_linear_class, quantize_config, repack=False)
+                    model = convert_to_marlin(
+                        model, quant_linear_class, quantize_config, repack=False
+                    )
                 else:
                     # Loading the GPTQ checkpoint to do the conversion.
                     # TODO: Avoid loading the model with wrong QuantLinear, and directly use
@@ -1107,25 +1339,37 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                         checkpoint=model_save_name,
                         device_map=device_map,
                         offload_state_dict=True,
-                        offload_buffers=True
+                        offload_buffers=True,
                     )
 
-                    model = convert_to_marlin(model, quant_linear_class, quantize_config, repack=True)
+                    model = convert_to_marlin(
+                        model, quant_linear_class, quantize_config, repack=True
+                    )
 
                     # Cache the converted model.
                     if is_local:
-                        model_save_name = os.path.join(model_name_or_path, "autogptq_model.safetensors")
+                        model_save_name = os.path.join(
+                            model_name_or_path, "autogptq_model.safetensors"
+                        )
                         safe_save(model.state_dict(), model_save_name)
                     else:
                         namespace, subfolder = model_name_or_path.split("/")
-                        assets_path = huggingface_hub.cached_assets_path(library_name="autogptq", namespace=namespace, subfolder=subfolder)
-                        model_save_name = os.path.join(assets_path, "autogptq_model.safetensors")
+                        assets_path = huggingface_hub.cached_assets_path(
+                            library_name="autogptq",
+                            namespace=namespace,
+                            subfolder=subfolder,
+                        )
+                        model_save_name = os.path.join(
+                            assets_path, "autogptq_model.safetensors"
+                        )
 
                         safe_save(model.state_dict(), model_save_name)
 
                 if inject_fused_attention or inject_fused_mlp:
                     # TODO: Validate whether that can be used.
-                    logger.info("Disabling fused attention and mlp injection because Marlin kernel is used")
+                    logger.info(
+                        "Disabling fused attention and mlp injection because Marlin kernel is used"
+                    )
                     inject_fused_attention = False
                     inject_fused_mlp = False
 
@@ -1135,7 +1379,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 checkpoint=model_save_name,
                 device_map=device_map,
                 offload_state_dict=True,
-                offload_buffers=True
+                offload_buffers=True,
             )
 
             # TODO: Why are we using this custom function and not dispatch_model?
@@ -1144,21 +1388,23 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             # Using QiGen.
 
             if quantize_config.desc_act:
-                NotImplementedError('desc_act=True is not yet supported.')
+                NotImplementedError("desc_act=True is not yet supported.")
             model = AutoModelForCausalLM.from_config(
-                config,
-                trust_remote_code=trust_remote_code,
-                torch_dtype=torch_dtype
+                config, trust_remote_code=trust_remote_code, torch_dtype=torch_dtype
             )
 
             layers = find_layers(model)
             ignore_layers = [cls.lm_head_name] + cls.outside_layer_modules
             for name in list(layers.keys()):
-                if any([name.startswith(ignore_layer) for ignore_layer in ignore_layers]):
-                    logger.info(f"{name} not been quantized, will be ignored when make_quant.")
+                if any(
+                    [name.startswith(ignore_layer) for ignore_layer in ignore_layers]
+                ):
+                    logger.info(
+                        f"{name} not been quantized, will be ignored when make_quant."
+                    )
                     del layers[name]
-            
-            if model_save_name.endswith('.safetensors'):
+
+            if model_save_name.endswith(".safetensors"):
                 checkpoint = safe_load(model_save_name)
             else:
                 checkpoint = torch.load(model_save_name)
@@ -1173,14 +1419,15 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 use_cuda_fp16=use_cuda_fp16,
                 desc_act=quantize_config.desc_act,
                 trainable=trainable,
-                use_qigen=True
+                use_qigen=True,
+                use_tritonv2=use_tritonv2,
             )
             preprocess_checkpoint_qigen(
                 model,
                 layers,
                 quantize_config.bits,
                 quantize_config.group_size,
-                checkpoint
+                checkpoint,
             )
             model.load_state_dict(checkpoint)
 
@@ -1193,14 +1440,18 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                     model.seqlen = model_config[key]
                     break
         else:
-            logger.warning("can't get model's sequence length from model config, will set to 4096.")
+            logger.warning(
+                "can't get model's sequence length from model config, will set to 4096."
+            )
             model.seqlen = 4096
 
         # == step5: (optional) inject optimized module == #
         if inject_fused_attention:
             if cls.fused_attn_module_type is None:
                 inject_fused_attention = False
-                logger.warning(f"{cls.__name__} hasn't fused attention module yet, will skip inject fused attention.")
+                logger.warning(
+                    f"{cls.__name__} hasn't fused attention module yet, will skip inject fused attention."
+                )
             else:
                 cls.fused_attn_module_type.inject_to_model(
                     model,
@@ -1211,17 +1462,17 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                     trainable=trainable,
                     bits=quantize_config.bits,
                     disable_exllama=disable_exllama,
-                    disable_exllamav2=disable_exllamav2
+                    disable_exllamav2=disable_exllamav2,
+                    use_tritonv2=use_tritonv2,
                 )
         if inject_fused_mlp:
             if cls.fused_mlp_module_type is None:
                 inject_fused_mlp = False
-                logger.warning(f"{cls.__name__} hasn't fused mlp module yet, will skip inject fused mlp.")
-            else:
-                cls.fused_mlp_module_type.inject_to_model(
-                    model,
-                    use_triton=use_triton
+                logger.warning(
+                    f"{cls.__name__} hasn't fused mlp module yet, will skip inject fused mlp."
                 )
+            else:
+                cls.fused_mlp_module_type.inject_to_model(model, use_triton=use_triton)
 
         # Any post-initialization that require device information, for example buffers initialization on device.
         model = autogptq_post_init(model, use_act_order=quantize_config.desc_act)
@@ -1229,8 +1480,9 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         model.eval()
 
         # == step6: (optional) warmup triton == #
-        if use_triton and warmup_triton:
+        if (use_triton or use_tritonv2) and warmup_triton:
             from ..nn_modules.qlinear.qlinear_triton import QuantLinear
+
             QuantLinear.warmup(model, seqlen=model.seqlen)
 
             if inject_fused_mlp and cls.fused_mlp_module_type is not None:
@@ -1238,17 +1490,21 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
 
         # == step7: make model compatible with peft
         cls.make_sure_compatible_with_peft(
-            model, use_triton, quantize_config.desc_act, quantize_config.group_size, bits=quantize_config.bits
+            model,
+            use_triton or use_tritonv2,
+            quantize_config.desc_act,
+            quantize_config.group_size,
+            bits=quantize_config.bits,
         )
 
         return cls(
             model,
             True,
             quantize_config,
-            is_triton_backend=use_triton,
+            is_triton_backend=use_triton or use_tritonv2,
             injected_fused_attention=inject_fused_attention,
-            injected_fused_mlp=inject_fused_mlp and use_triton,
-            trainable=trainable
+            injected_fused_mlp=inject_fused_mlp and (use_triton or use_tritonv2),
+            trainable=trainable,
         )
 
     def warmup_triton(self, enabled: bool = True):
@@ -1259,6 +1515,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             return
 
         from ..nn_modules.qlinear.qlinear_triton import QuantLinear
+
         QuantLinear.warmup(self.model, seqlen=self.model.seqlen)
 
         if self.fused_mlp_module_type is not None:
@@ -1266,7 +1523,9 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
 
     def enable_trainable_mode(self, enabled: bool = True):
         if not self.is_triton_backend and enabled:
-            raise NotImplementedError("For now, trainable mode only supports triton backend.")
+            raise NotImplementedError(
+                "For now, trainable mode only supports triton backend."
+            )
         for n, m in self.model.named_modules():
             if hasattr(m, "trainable"):
                 setattr(m, "trainable", enabled)
@@ -1275,10 +1534,16 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         self.enable_trainable_mode(enabled=False)
 
     @staticmethod
-    def make_sure_compatible_with_peft(model: PreTrainedModel, use_triton: bool, desc_act: bool, group_size: int, bits: int):
+    def make_sure_compatible_with_peft(
+        model: PreTrainedModel,
+        use_triton: bool,
+        desc_act: bool,
+        group_size: int,
+        bits: int,
+    ):
         GeneralQuantLinear.inject_to_model(
             model,
-            dynamically_import_QuantLinear(use_triton, desc_act, group_size, bits=bits)
+            dynamically_import_QuantLinear(use_triton, desc_act, group_size, bits=bits),
         )
 
     def __getattr__(self, item):
@@ -1286,5 +1551,6 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             return super().__getattr__(item)
         except:
             return getattr(self.model, item)
+
 
 __all__ = ["BaseGPTQForCausalLM", "BaseQuantizeConfig"]

--- a/auto_gptq/modeling/_utils.py
+++ b/auto_gptq/modeling/_utils.py
@@ -116,6 +116,7 @@ def make_quant(
                 (not (desc_act) or group_size == -1)
                 and not use_triton
                 and not use_qigen
+                and not use_tritonv2
             ):
                 new_layer = QuantLinear(
                     bits,
@@ -153,6 +154,7 @@ def make_quant(
             disable_exllama=disable_exllama,
             disable_exllamav2=disable_exllamav2,
             use_qigen=use_qigen,
+            use_tritonv2=use_tritonv2,
         )
 
 

--- a/auto_gptq/modeling/_utils.py
+++ b/auto_gptq/modeling/_utils.py
@@ -1,20 +1,21 @@
-from logging import getLogger
-from typing import Union, Optional
-from tqdm import tqdm
 import copy
 import gc
+from logging import getLogger
+from typing import Optional, Union
 
 import accelerate
+import numpy as np
 import torch
 import torch.nn as nn
-from transformers import AutoConfig
 import transformers
+from tqdm import tqdm
+from transformers import AutoConfig
 
-from ._const import SUPPORTED_MODELS, CPU, CUDA_0, EXLLAMA_DEFAULT_MAX_INPUT_LENGTH
-from ..utils.import_utils import dynamically_import_QuantLinear
-import numpy as np
-from ..nn_modules.qlinear.qlinear_marlin import dequantize_weight
 from ..nn_modules.qlinear.qlinear_marlin import QuantLinear as MarlinQuantLinear
+from ..nn_modules.qlinear.qlinear_marlin import dequantize_weight
+from ..utils.import_utils import dynamically_import_QuantLinear
+from ._const import CPU, CUDA_0, EXLLAMA_DEFAULT_MAX_INPUT_LENGTH, SUPPORTED_MODELS
+
 logger = getLogger(__name__)
 
 
@@ -33,15 +34,19 @@ def move_to_device(obj: Optional[Union[torch.Tensor, nn.Module]], device: torch.
         return obj
 
 
-def find_layers(module, layers=None, name=''):
+def find_layers(module, layers=None, name=""):
     if not layers:
         layers = [transformers.pytorch_utils.Conv1D, nn.Conv2d, nn.Linear]
     for layer in layers:
-        if isinstance(module,layer):
+        if isinstance(module, layer):
             return {name: module}
     res = {}
     for name1, child in module.named_children():
-        res.update(find_layers(child, layers=layers, name=name + '.' + name1 if name != '' else name1))
+        res.update(
+            find_layers(
+                child, layers=layers, name=name + "." + name1 if name != "" else name1
+            )
+        )
     return res
 
 
@@ -62,14 +67,15 @@ def make_quant(
     names,
     bits,
     group_size,
-    name='',
+    name="",
     use_triton: bool = False,
     disable_exllama: Optional[bool] = None,
-    disable_exllamav2: bool = False, 
+    disable_exllamav2: bool = False,
     use_qigen: bool = False,
     use_cuda_fp16: bool = True,
     desc_act: bool = False,
-    trainable: bool = False
+    trainable: bool = False,
+    use_tritonv2: bool = False,
 ):
     # If disable_exllamav2 is True, we want to fall back on the exllama kernel and not the cuda/cuda_old ones.
     if disable_exllama is None:
@@ -78,31 +84,59 @@ def make_quant(
         else:
             disable_exllama = True
 
-    QuantLinear = dynamically_import_QuantLinear(use_triton=use_triton, desc_act=desc_act, group_size=group_size, bits=bits, disable_exllama=disable_exllama, disable_exllamav2=disable_exllamav2, use_qigen=use_qigen)
+    QuantLinear = dynamically_import_QuantLinear(
+        use_triton=use_triton,
+        desc_act=desc_act,
+        group_size=group_size,
+        bits=bits,
+        disable_exllama=disable_exllama,
+        disable_exllamav2=disable_exllamav2,
+        use_qigen=use_qigen,
+        use_tritonv2=use_tritonv2,
+    )
 
     if isinstance(module, QuantLinear):
         return
     for attr in dir(module):
         tmp = getattr(module, attr)
-        name1 = name + '.' + attr if name != '' else attr
+        name1 = name + "." + attr if name != "" else attr
         if name1 in names:
             ori_layer_device = get_device(getattr(module, attr))
             delattr(module, attr)
-            if isinstance(tmp,nn.Linear):
+            if isinstance(tmp, nn.Linear):
                 in_features = tmp.in_features
                 out_features = tmp.out_features
-            elif isinstance(tmp,nn.Conv2d):
+            elif isinstance(tmp, nn.Conv2d):
                 in_features = tmp.in_channels
                 out_features = tmp.out_channels
-            elif isinstance(tmp,transformers.pytorch_utils.Conv1D):            
+            elif isinstance(tmp, transformers.pytorch_utils.Conv1D):
                 in_features = tmp.weight.shape[0]
                 out_features = tmp.weight.shape[1]
-            if (not(desc_act) or group_size == -1) and not use_triton and not use_qigen:
+            if (
+                (not (desc_act) or group_size == -1)
+                and not use_triton
+                and not use_qigen
+            ):
                 new_layer = QuantLinear(
-                    bits, group_size, in_features, out_features, True, use_cuda_fp16=use_cuda_fp16, trainable=trainable, weight_dtype=tmp.weight.dtype
+                    bits,
+                    group_size,
+                    in_features,
+                    out_features,
+                    True,
+                    use_cuda_fp16=use_cuda_fp16,
+                    trainable=trainable,
+                    weight_dtype=tmp.weight.dtype,
                 )
             else:
-                new_layer = QuantLinear(bits, group_size, in_features, out_features, True, trainable=trainable, weight_dtype=tmp.weight.dtype)
+                new_layer = QuantLinear(
+                    bits,
+                    group_size,
+                    in_features,
+                    out_features,
+                    True,
+                    trainable=trainable,
+                    weight_dtype=tmp.weight.dtype,
+                )
             new_layer.device = ori_layer_device
             setattr(module, attr, new_layer.to(ori_layer_device))
     for name1, child in module.named_children():
@@ -111,15 +145,16 @@ def make_quant(
             names,
             bits,
             group_size,
-            name + '.' + name1 if name != '' else name1,
+            name + "." + name1 if name != "" else name1,
             use_triton=use_triton,
             use_cuda_fp16=use_cuda_fp16,
             desc_act=desc_act,
             trainable=trainable,
             disable_exllama=disable_exllama,
             disable_exllamav2=disable_exllamav2,
-            use_qigen=use_qigen
+            use_qigen=use_qigen,
         )
+
 
 @torch.no_grad()
 def convert_to_marlin(model, model_quantlinear, quantization_config, repack: bool):
@@ -135,7 +170,9 @@ def convert_to_marlin(model, model_quantlinear, quantization_config, repack: boo
     else:
         message = "Overriding QuantLinear layers to use Marlin's QuantLinear..."
 
-    for name, module in tqdm(model.named_modules(), desc=message, total=len(list(model.named_modules()))):
+    for name, module in tqdm(
+        model.named_modules(), desc=message, total=len(list(model.named_modules()))
+    ):
         if not isinstance(module, model_quantlinear):
             continue
 
@@ -145,7 +182,7 @@ def convert_to_marlin(model, model_quantlinear, quantization_config, repack: boo
             bias = None
 
         parent_name = ".".join(name.split(".")[:-1])
-        layer_name = name[len(parent_name) + 1:]
+        layer_name = name[len(parent_name) + 1 :]
 
         # Dequantize the weight.
         if repack:
@@ -153,21 +190,29 @@ def convert_to_marlin(model, model_quantlinear, quantization_config, repack: boo
             dequantized_weight = dequantized_weight.to(torch.float16)
 
             if not torch.all(dequantized_qzeros == 8):
-                raise ValueError(f"Marlin kernel is compatible only with checkpoints using symetric quantization. Found non-symmetric quantization for the weight {name}.")
+                raise ValueError(
+                    f"Marlin kernel is compatible only with checkpoints using symetric quantization. Found non-symmetric quantization for the weight {name}."
+                )
 
             linear_module = nn.Linear(
                 in_features=dequantized_weight.shape[1],
                 out_features=dequantized_weight.shape[0],
                 bias=bias is not None,
                 dtype=torch.float16,
-                device="cuda"
+                device="cuda",
             )
             linear_module.weight.data.copy_(dequantized_weight)
 
             if bias is not None:
                 linear_module.bias.data.copy_(bias)
         else:
-            linear_module = nn.Linear(module.infeatures, module.outfeatures, bias=bias is not None, dtype=torch.float16, device="cuda")
+            linear_module = nn.Linear(
+                module.infeatures,
+                module.outfeatures,
+                bias=bias is not None,
+                dtype=torch.float16,
+                device="cuda",
+            )
 
         # Create new linear method and copy to model.
         new_module = MarlinQuantLinear(
@@ -180,7 +225,9 @@ def convert_to_marlin(model, model_quantlinear, quantization_config, repack: boo
         )
 
         if repack:
-            new_module.pack(linear_module, scales=copy.deepcopy(module.scales.data.t()).to("cuda"))
+            new_module.pack(
+                linear_module, scales=copy.deepcopy(module.scales.data.t()).to("cuda")
+            )
 
         # Save to parent.
         parent_module = model.get_submodule(parent_name)
@@ -194,65 +241,112 @@ def convert_to_marlin(model, model_quantlinear, quantization_config, repack: boo
         gc.collect()
     return model
 
+
 def preprocess_checkpoint_qigen(
     module,
     names,
     bits,
     group_size,
     checkpoint,
-    name='',
+    name="",
 ):
     try:
         import cQIGen as qinfer
     except ImportError:
-        logger.error('cQIGen not installed.')
+        logger.error("cQIGen not installed.")
         raise
 
-    QuantLinear = dynamically_import_QuantLinear(use_triton=False, desc_act=False, group_size=group_size, bits=bits, disable_exllama=False, use_qigen=True)
+    QuantLinear = dynamically_import_QuantLinear(
+        use_triton=False,
+        desc_act=False,
+        group_size=group_size,
+        bits=bits,
+        disable_exllama=False,
+        use_qigen=True,
+    )
     if isinstance(module, QuantLinear):
         in_features = module.infeatures
         out_features = module.outfeatures
-        
-        zeros = checkpoint[name + '.qzeros']
-        scales = checkpoint[name + '.scales'].float()
-        
+
+        zeros = checkpoint[name + ".qzeros"]
+        scales = checkpoint[name + ".scales"].float()
+
         if zeros.dtype != torch.float32:
             new_zeros = torch.zeros_like(scales).float().contiguous()
             if bits == 4:
-                qinfer.unpack_zeros4(zeros, new_zeros, new_zeros.shape[0], new_zeros.shape[1])
+                qinfer.unpack_zeros4(
+                    zeros, new_zeros, new_zeros.shape[0], new_zeros.shape[1]
+                )
             elif bits == 2:
-                qinfer.unpack_zeros2(zeros, new_zeros, new_zeros.shape[0], new_zeros.shape[1])
+                qinfer.unpack_zeros2(
+                    zeros, new_zeros, new_zeros.shape[0], new_zeros.shape[1]
+                )
             elif bits == 3:
                 logger.info("Unpacking zeros for 3 bits")
             new_scales = scales.contiguous()
         else:
             if scales.shape[1] != out_features:
-                new_scales = scales.transpose(0,1).contiguous()
+                new_scales = scales.transpose(0, 1).contiguous()
             else:
                 new_scales = scales.contiguous()
             if zeros.shape[1] != out_features:
-                new_zeros = zeros.transpose(0,1).contiguous()
+                new_zeros = zeros.transpose(0, 1).contiguous()
             else:
                 new_zeros = zeros.contiguous()
 
-        checkpoint[name + '.zeros'],checkpoint[name + '.scales'] = new_zeros, new_scales
-        del checkpoint[name + '.qzeros']
-        del checkpoint[name + '.g_idx']
-        if name + '.bias' in checkpoint:
-            checkpoint[name + '.bias'] = checkpoint[name + '.bias'].float()
+        checkpoint[name + ".zeros"], checkpoint[name + ".scales"] = (
+            new_zeros,
+            new_scales,
+        )
+        del checkpoint[name + ".qzeros"]
+        del checkpoint[name + ".g_idx"]
+        if name + ".bias" in checkpoint:
+            checkpoint[name + ".bias"] = checkpoint[name + ".bias"].float()
         else:
-            checkpoint[name + '.bias'] = torch.zeros(out_features)
-        checkpoint_qweight = checkpoint[name + '.qweight'].int().contiguous()
+            checkpoint[name + ".bias"] = torch.zeros(out_features)
+        checkpoint_qweight = checkpoint[name + ".qweight"].int().contiguous()
         if bits == 4:
-            qweight = torch.zeros(int(in_features // 8 * out_features)).int().contiguous()
-            qinfer.pack4(checkpoint_qweight, qweight, in_features // 8, out_features, module.mb, module.tb, module.cutoff)# * (module.tt//tb))
+            qweight = (
+                torch.zeros(int(in_features // 8 * out_features)).int().contiguous()
+            )
+            qinfer.pack4(
+                checkpoint_qweight,
+                qweight,
+                in_features // 8,
+                out_features,
+                module.mb,
+                module.tb,
+                module.cutoff,
+            )  # * (module.tt//tb))
         elif bits == 3:
-            qweight = torch.zeros(int(in_features // 32 * 3 * out_features)).int().contiguous()
-            qinfer.pack3(checkpoint_qweight, qweight, in_features // 32 * 3, out_features, module.mb // 32 * 3, module.tb, module.cutoff)
+            qweight = (
+                torch.zeros(int(in_features // 32 * 3 * out_features))
+                .int()
+                .contiguous()
+            )
+            qinfer.pack3(
+                checkpoint_qweight,
+                qweight,
+                in_features // 32 * 3,
+                out_features,
+                module.mb // 32 * 3,
+                module.tb,
+                module.cutoff,
+            )
         elif bits == 2:
-            qweight = torch.zeros(int(in_features // 16 * out_features)).int().contiguous()
-            qinfer.pack2(checkpoint_qweight, qweight, in_features // 16, out_features, module.mb, module.tb, module.cutoff)# * (module.tt//tb))
-        checkpoint[name + '.qweight'] = qweight
+            qweight = (
+                torch.zeros(int(in_features // 16 * out_features)).int().contiguous()
+            )
+            qinfer.pack2(
+                checkpoint_qweight,
+                qweight,
+                in_features // 16,
+                out_features,
+                module.mb,
+                module.tb,
+                module.cutoff,
+            )  # * (module.tt//tb))
+        checkpoint[name + ".qweight"] = qweight
         return
 
     for name1, child in module.named_children():
@@ -262,8 +356,9 @@ def preprocess_checkpoint_qigen(
             bits,
             group_size,
             checkpoint,
-            name + '.' + name1 if name != '' else name1,
+            name + "." + name1 if name != "" else name1,
         )
+
 
 def pack_model(
     model,
@@ -274,17 +369,34 @@ def pack_model(
     use_cuda_fp16=True,
     desc_act=False,
     warmup_triton: bool = False,
-    force_layer_back_to_cpu: bool = False
+    force_layer_back_to_cpu: bool = False,
 ):
-    QuantLinear = dynamically_import_QuantLinear(use_triton=use_triton, desc_act=desc_act, group_size=group_size, bits=bits, disable_exllama=False, disable_exllamav2=True)
+    QuantLinear = dynamically_import_QuantLinear(
+        use_triton=use_triton,
+        desc_act=desc_act,
+        group_size=group_size,
+        bits=bits,
+        disable_exllama=False,
+        disable_exllamav2=True,
+    )
 
     if force_layer_back_to_cpu:
         model.to(CPU)
 
-    logger.info('Packing model...')
+    logger.info("Packing model...")
     layers = find_layers(model)
     layers = {n: layers[n] for n in quantizers}
-    make_quant(model, quantizers, bits, group_size, use_triton=use_triton, use_cuda_fp16=use_cuda_fp16, desc_act=desc_act, disable_exllama=False, disable_exllamav2=True)
+    make_quant(
+        model,
+        quantizers,
+        bits,
+        group_size,
+        use_triton=use_triton,
+        use_cuda_fp16=use_cuda_fp16,
+        desc_act=desc_act,
+        disable_exllama=False,
+        disable_exllamav2=True,
+    )
     qlayers = find_layers(model, [QuantLinear])
     for name in qlayers:
         logger.info(name)
@@ -292,10 +404,15 @@ def pack_model(
         # so far can only pack layer on CPU
         layer_device = qlayers[name].device
         qlayers[name].to(CPU)
-        layers[name], scale, zero, g_idx = layers[name].to(CPU), scale.to(CPU), zero.to(CPU), g_idx.to(CPU)
+        layers[name], scale, zero, g_idx = (
+            layers[name].to(CPU),
+            scale.to(CPU),
+            zero.to(CPU),
+            g_idx.to(CPU),
+        )
         qlayers[name].pack(layers[name], scale, zero, g_idx)
         qlayers[name].to(layer_device)
-    logger.info('Model packed.')
+    logger.info("Model packed.")
 
     if use_triton and warmup_triton:
         logger.warning(
@@ -313,7 +430,7 @@ def check_and_get_model_type(model_dir, trust_remote_code=False):
 
 
 def simple_dispatch_model(model, device_map):
-    from accelerate.hooks import add_hook_to_module, AlignDevicesHook
+    from accelerate.hooks import AlignDevicesHook, add_hook_to_module
 
     if "" in device_map:
         d = device_map[""]
@@ -322,7 +439,10 @@ def simple_dispatch_model(model, device_map):
         return model
 
     tied_params = accelerate.utils.modeling.find_tied_parameters(model)
-    if set(device_map.values()) == {"cpu"} or set(device_map.values()) == {"cpu", "disk"}:
+    if set(device_map.values()) == {"cpu"} or set(device_map.values()) == {
+        "cpu",
+        "disk",
+    }:
         main_device = "cpu"
     else:
         main_device = [d for d in device_map.values() if d not in ["cpu", "disk"]][0]
@@ -331,10 +451,14 @@ def simple_dispatch_model(model, device_map):
     prev_hook = None
     for idx, (n, d) in enumerate(cpu_offload_group):
         m = get_module_by_name_suffix(model, n)
-        _, prev_hook = accelerate.cpu_offload_with_hook(m, execution_device=main_device, prev_module_hook=prev_hook)
+        _, prev_hook = accelerate.cpu_offload_with_hook(
+            m, execution_device=main_device, prev_module_hook=prev_hook
+        )
     # set first cpu offload module's prev_module_hook to the last cpu offload module's hook
     if len(cpu_offload_group) > 1:
-        get_module_by_name_suffix(model, cpu_offload_group[0][0])._hf_hook.prev_module_hook = prev_hook
+        get_module_by_name_suffix(
+            model, cpu_offload_group[0][0]
+        )._hf_hook.prev_module_hook = prev_hook
 
     for n, d in device_map.items():
         m = get_module_by_name_suffix(model, n)
@@ -348,7 +472,9 @@ def simple_dispatch_model(model, device_map):
     return model
 
 
-def autogptq_post_init(model, use_act_order: bool, max_input_length: Optional[int] = None):
+def autogptq_post_init(
+    model, use_act_order: bool, max_input_length: Optional[int] = None
+):
     """
     The max_input_length argument is specific to the exllama backend, that requires to initialize a buffer temp_state.
     """
@@ -362,9 +488,9 @@ def autogptq_post_init(model, use_act_order: bool, max_input_length: Optional[in
             if device not in device_to_buffers_size:
                 device_to_buffers_size[device] = {
                     "max_dq_buffer_size": 1,
-                    "max_inner_outer_dim": 1
+                    "max_inner_outer_dim": 1,
                 }
-            
+
             if not use_act_order:
                 submodule._use_act_order = False
             else:
@@ -381,18 +507,27 @@ def autogptq_post_init(model, use_act_order: bool, max_input_length: Optional[in
                 submodule.act_order = True
             """
 
-            device_to_buffers_size[device]["max_dq_buffer_size"] = max(device_to_buffers_size[device]["max_dq_buffer_size"], submodule.qweight.numel() * 8)
+            device_to_buffers_size[device]["max_dq_buffer_size"] = max(
+                device_to_buffers_size[device]["max_dq_buffer_size"],
+                submodule.qweight.numel() * 8,
+            )
 
             if use_act_order:
-                device_to_buffers_size[device]["max_inner_outer_dim"] = max(device_to_buffers_size[device]["max_inner_outer_dim"], submodule.infeatures, submodule.outfeatures)
+                device_to_buffers_size[device]["max_inner_outer_dim"] = max(
+                    device_to_buffers_size[device]["max_inner_outer_dim"],
+                    submodule.infeatures,
+                    submodule.outfeatures,
+                )
 
     if model_uses_exllama:
         # To be honest this is quite ugly, not proud of this.
         try:
             from exllama_kernels import prepare_buffers, set_tuning_params
         except ImportError as e:
-            raise ImportError(f"Could not import exllama backend dependencies prepare_buffers, set_tuning_params with the following error: {e}")
-        
+            raise ImportError(
+                f"Could not import exllama backend dependencies prepare_buffers, set_tuning_params with the following error: {e}"
+            )
+
         device_to_buffers = {}
 
         if use_act_order:
@@ -402,22 +537,32 @@ def autogptq_post_init(model, use_act_order: bool, max_input_length: Optional[in
                 max_input_len = max_input_length
         else:
             if max_input_length is not None:
-                logger.info("Using exllama backend without act-order, the parameter max_input_length was set although not needed, it will be ignored.")
+                logger.info(
+                    "Using exllama backend without act-order, the parameter max_input_length was set although not needed, it will be ignored."
+                )
             max_input_len = 1
 
         for device, buffers_size in device_to_buffers_size.items():
             # The temp_state buffer is required to reorder X in the act-order case.
             # The temp_dq buffer is required to dequantize weights when using cuBLAS, typically for the prefill.
             device_to_buffers[device] = {
-                "temp_state": torch.zeros((max_input_len, buffers_size["max_inner_outer_dim"]), dtype=torch.float16, device=device),
-                "temp_dq": torch.zeros((1, buffers_size["max_dq_buffer_size"]), dtype=torch.float16, device=device),
+                "temp_state": torch.zeros(
+                    (max_input_len, buffers_size["max_inner_outer_dim"]),
+                    dtype=torch.float16,
+                    device=device,
+                ),
+                "temp_dq": torch.zeros(
+                    (1, buffers_size["max_dq_buffer_size"]),
+                    dtype=torch.float16,
+                    device=device,
+                ),
                 "max_dq_buffer_size": buffers_size["max_dq_buffer_size"],
                 "max_inner_outer_dim": buffers_size["max_inner_outer_dim"],
             }
-        
+
         # Buffers need to be persistent to avoid any bug.
         model.device_to_buffers = device_to_buffers
-    
+
         for device, buffers in model.device_to_buffers.items():
             prepare_buffers(device, buffers["temp_state"], buffers["temp_dq"])
 
@@ -435,53 +580,65 @@ def autogptq_post_init(model, use_act_order: bool, max_input_length: Optional[in
     ## exllamav2
     fixed_bytes = {}
     model_uses_exllamav2 = False
-    
+
     for _, submodule in model.named_modules():
         if hasattr(submodule, "QUANT_TYPE") and submodule.QUANT_TYPE == "exllamav2":
             model_uses_exllamav2 = True
             device = submodule.qweight.device
             scratch_fixed = submodule.scratch_space_fixed()
-            fixed_bytes[device] = max(scratch_fixed, fixed_bytes.get(device,0))
+            fixed_bytes[device] = max(scratch_fixed, fixed_bytes.get(device, 0))
 
     if model_uses_exllamav2:
         from ..nn_modules.qlinear.qlinear_exllamav2 import ExLlamaV2DeviceTensors
-        device_tensors = {} 
+
+        device_tensors = {}
         for device, scratch_bytes in fixed_bytes.items():
             device_tensors[device] = ExLlamaV2DeviceTensors(device.index, scratch_bytes)
-        
+
         # have persistent buffers, otherwise we will get OOM
         model.device_tensors = device_tensors
 
         for _, submodule in model.named_modules():
             if hasattr(submodule, "QUANT_TYPE") and submodule.QUANT_TYPE == "exllamav2":
                 device = submodule.qweight.device
-                submodule.post_init(temp_dq = model.device_tensors[device])
+                submodule.post_init(temp_dq=model.device_tensors[device])
     torch.cuda.empty_cache()
 
     return model
 
 
-def make_sure_no_tensor_in_meta_device(model, use_triton, desc_act, group_size, bits: int):
-    QuantLinear = dynamically_import_QuantLinear(use_triton, desc_act, group_size, bits=bits)
+def make_sure_no_tensor_in_meta_device(
+    model, use_triton, desc_act, group_size, bits: int
+):
+    QuantLinear = dynamically_import_QuantLinear(
+        use_triton, desc_act, group_size, bits=bits
+    )
     for n, m in model.named_modules():
         if isinstance(m, QuantLinear) and m.bias.device == torch.device("meta"):
-            m.register_buffer('bias', torch.zeros((m.outfeatures), dtype=torch.float16, device="cpu"))
+            m.register_buffer(
+                "bias", torch.zeros((m.outfeatures), dtype=torch.float16, device="cpu")
+            )
 
 
 def awq_reverse_reorder_int_tensor(int_tensor, bits: int):
     assert bits == 4
 
     int_tensor = int_tensor.T.contiguous()
-    compress_ratio = (32 // bits)
+    compress_ratio = 32 // bits
     assert int_tensor.shape[-1] % compress_ratio == 0
-    
+
     order_map = [0, 2, 4, 6, 1, 3, 5, 7]
     order_tensor = torch.tensor(
-        order_map, dtype=torch.int32, device=int_tensor.device).reshape(1, -1)
-    order_tensor = order_tensor.repeat(
-        int_tensor.shape[1]//compress_ratio, 1)
-    order_tensor = order_tensor + torch.arange(0, int_tensor.shape[1],
-                                                compress_ratio, dtype=torch.int32, device=int_tensor.device).reshape(-1, 1)
+        order_map, dtype=torch.int32, device=int_tensor.device
+    ).reshape(1, -1)
+    order_tensor = order_tensor.repeat(int_tensor.shape[1] // compress_ratio, 1)
+    order_tensor = order_tensor + torch.arange(
+        0,
+        int_tensor.shape[1],
+        compress_ratio,
+        dtype=torch.int32,
+        device=int_tensor.device,
+    ).reshape(-1, 1)
     order_tensor = order_tensor.reshape(-1)
 
     reverse_order_tensor = torch.arange(order_tensor.shape[0]).cuda()[order_tensor]
@@ -490,7 +647,13 @@ def awq_reverse_reorder_int_tensor(int_tensor, bits: int):
     return int_tensor
 
 
-def unpack_awq(awq_qweight: torch.Tensor, awq_qzeros: torch.Tensor, awq_scales: torch.Tensor, bits: int, group_size: int):
+def unpack_awq(
+    awq_qweight: torch.Tensor,
+    awq_qzeros: torch.Tensor,
+    awq_scales: torch.Tensor,
+    bits: int,
+    group_size: int,
+):
     """
     Args:
         awq_qweight (`torch.LongTensor`):
@@ -499,7 +662,7 @@ def unpack_awq(awq_qweight: torch.Tensor, awq_qzeros: torch.Tensor, awq_scales: 
             Expected shape: (in_features // group_size, out_features // (32 // bits))
         awq_scales (`torch.LongTensor`):
             Expected shape: (in_features // group_size, out_features)
-    
+
     Returns:
         fp16_weight (`torch.LongTensor`):
             With shape (in_features, out_features).
@@ -517,19 +680,23 @@ def unpack_awq(awq_qweight: torch.Tensor, awq_qzeros: torch.Tensor, awq_scales: 
 
     infeatures = awq_qweight.shape[0]
 
-    wf = torch.tensor(list(range(0, 32, bits)), dtype=torch.int32, device=qzeros.device).unsqueeze(0)
+    wf = torch.tensor(
+        list(range(0, 32, bits)), dtype=torch.int32, device=qzeros.device
+    ).unsqueeze(0)
     zeros = torch.bitwise_right_shift(torch.unsqueeze(qzeros, 2), wf.unsqueeze(0)).to(
-        torch.int16 if bits == 8 else torch.int8)
+        torch.int16 if bits == 8 else torch.int8
+    )
 
-    #zeros = zeros + 1
+    # zeros = zeros + 1
 
-    torch.bitwise_and(zeros, (2 ** bits) - 1, out=zeros)
+    torch.bitwise_and(zeros, (2**bits) - 1, out=zeros)
 
     zeros = zeros.reshape(-1, 1, zeros.shape[1] * zeros.shape[2])
 
-    weight = torch.bitwise_right_shift(torch.unsqueeze(
-        qweight, 1), wf.unsqueeze(-1)).to(torch.int16 if bits == 8 else torch.int8)
-    torch.bitwise_and(weight, (2 ** bits) - 1, out=weight)
+    weight = torch.bitwise_right_shift(
+        torch.unsqueeze(qweight, 1), wf.unsqueeze(-1)
+    ).to(torch.int16 if bits == 8 else torch.int8)
+    torch.bitwise_and(weight, (2**bits) - 1, out=weight)
     weight = weight.reshape(-1, group_size, weight.shape[2])
 
     weight = weight.view(-1, weight.shape[-1])
@@ -544,7 +711,9 @@ def unpack_awq(awq_qweight: torch.Tensor, awq_qzeros: torch.Tensor, awq_scales: 
     zeros = zeros.contiguous()
     scale_zeros = zeros * scales
 
-    g_idx =  torch.tensor([i // group_size for i in range(infeatures)], dtype=torch.int32)
+    g_idx = torch.tensor(
+        [i // group_size for i in range(infeatures)], dtype=torch.int32
+    )
     scale_mat = scales[g_idx]
     scale_zeros_mat = scale_zeros[g_idx].half()
 
@@ -554,7 +723,14 @@ def unpack_awq(awq_qweight: torch.Tensor, awq_qzeros: torch.Tensor, awq_scales: 
 
     return fp16_weight, zeros
 
-def pack_from_tensors(unpacked_qweight: torch.Tensor, unpacked_qzeros: torch.Tensor, awq_scales: torch.Tensor, bits: int, group_size: int):
+
+def pack_from_tensors(
+    unpacked_qweight: torch.Tensor,
+    unpacked_qzeros: torch.Tensor,
+    awq_scales: torch.Tensor,
+    bits: int,
+    group_size: int,
+):
     """
     Args:
         unpacked_qweight (`torch.LongTensor`):
@@ -563,7 +739,7 @@ def pack_from_tensors(unpacked_qweight: torch.Tensor, unpacked_qzeros: torch.Ten
             Expected shape: (in_features // group_size, out_features)
         awq_scales (`torch.LongTensor`):
             Expected shape: (in_features // group_size, out_features)
-    
+
     Returns:
         qweight (`torch.LongTensor`):
             With shape (in_features // (32 // bits), out_features)
@@ -594,10 +770,9 @@ def pack_from_tensors(unpacked_qweight: torch.Tensor, unpacked_qzeros: torch.Ten
         g_idx = idx // group_size
 
         intweight.append(
-            torch.round(
-                (
-                    W[:, idx] + scale_zeros[:, g_idx]) / scales[:, g_idx]
-            ).to(torch.int)[:, None]
+            torch.round((W[:, idx] + scale_zeros[:, g_idx]) / scales[:, g_idx]).to(
+                torch.int
+            )[:, None]
         )
     intweight = torch.cat(intweight, dim=1)
     intweight = intweight.t().contiguous()
@@ -618,10 +793,13 @@ def pack_from_tensors(unpacked_qweight: torch.Tensor, unpacked_qzeros: torch.Ten
     qweight = torch.from_numpy(qweight)
 
     unpacked_qzeros = unpacked_qzeros - 1
-    torch.bitwise_and(unpacked_qzeros, (2 ** bits) - 1, out=unpacked_qzeros)
+    torch.bitwise_and(unpacked_qzeros, (2**bits) - 1, out=unpacked_qzeros)
 
     unpacked_qzeros = unpacked_qzeros.numpy().astype(np.uint32)
-    qzeros = np.zeros((unpacked_qzeros.shape[0], unpacked_qzeros.shape[1] // 32 * bits), dtype=np.uint32)
+    qzeros = np.zeros(
+        (unpacked_qzeros.shape[0], unpacked_qzeros.shape[1] // 32 * bits),
+        dtype=np.uint32,
+    )
     i = 0
     col = 0
     while col < qzeros.shape[1]:
@@ -634,6 +812,7 @@ def pack_from_tensors(unpacked_qweight: torch.Tensor, unpacked_qzeros: torch.Ten
     qzeros = torch.from_numpy(qzeros)
 
     return qweight, qzeros
+
 
 __all__ = [
     "get_device",

--- a/auto_gptq/nn_modules/fused_llama_attn.py
+++ b/auto_gptq/nn_modules/fused_llama_attn.py
@@ -1,11 +1,15 @@
 import math
+
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
-from transformers.models.llama.modeling_llama import LlamaAttention, apply_rotary_pos_emb
+from transformers.models.llama.modeling_llama import (
+    LlamaAttention,
+    apply_rotary_pos_emb,
+)
 
-from ._fused_base import FusedBaseAttentionModule
 from ..utils.import_utils import compare_pytorch_version, dynamically_import_QuantLinear
+from ._fused_base import FusedBaseAttentionModule
 
 
 class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
@@ -36,7 +40,11 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
         self.rotary_emb = rotary_emb
 
     def _shape(self, tensor, seq_len, bsz):
-        return tensor.view(bsz, seq_len, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+        return (
+            tensor.view(bsz, seq_len, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+            .contiguous()
+        )
 
     def forward(
         self,
@@ -46,18 +54,26 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
         position_ids=None,
         output_attentions=False,
         use_cache=False,
-        **kwargs
+        **kwargs,
     ):
         """Input shape: Batch x Time x Channel"""
 
         bsz, q_len, _ = hidden_states.size()
 
         qkv_states = self.qkv_proj(hidden_states)
-        query_states, key_states, value_states = torch.split(qkv_states, self.hidden_size, dim=2)
+        query_states, key_states, value_states = torch.split(
+            qkv_states, self.hidden_size, dim=2
+        )
 
-        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-        key_states = key_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-        value_states = value_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        query_states = query_states.view(
+            bsz, q_len, self.num_heads, self.head_dim
+        ).transpose(1, 2)
+        key_states = key_states.view(
+            bsz, q_len, self.num_heads, self.head_dim
+        ).transpose(1, 2)
+        value_states = value_states.view(
+            bsz, q_len, self.num_heads, self.head_dim
+        ).transpose(1, 2)
 
         kv_seq_len = key_states.shape[-2]
         if past_key_value is not None:
@@ -68,15 +84,19 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
                     "with a layer index. Please open an issue in AutoGPTQ if you hit this."
                 )
             kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
-        
+
         cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
-        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
+        query_states, key_states = apply_rotary_pos_emb(
+            query_states, key_states, cos, sin, position_ids
+        )
         # [bsz, nh, t, hd]
 
         if past_key_value is not None:
             cache_kwargs = {"sin": sin, "cos": cos}  # Specific to RoPE models
-            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
-        
+            key_states, value_states = past_key_value.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
+
         if use_cache:
             # Since qkv_proj is fused, query_states etc will hold a reference to the original qkv_states tensor
             # which can cause excessive memory usage by the cache. `contiguous` is a convenient way to workaround this.
@@ -90,11 +110,13 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
                 key_states,
                 value_states,
                 attn_mask=attention_mask,
-                is_causal=attention_mask is None and q_len > 1
+                is_causal=attention_mask is None and q_len > 1,
             )
             attn_weights = None
         else:
-            attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
+            attn_weights = torch.matmul(
+                query_states, key_states.transpose(2, 3)
+            ) / math.sqrt(self.head_dim)
 
             if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
                 raise ValueError(
@@ -108,10 +130,14 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
                         f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
                     )
                 attn_weights = attn_weights + attention_mask
-                attn_weights = torch.max(attn_weights, torch.tensor(torch.finfo(attn_weights.dtype).min))
+                attn_weights = torch.max(
+                    attn_weights, torch.tensor(torch.finfo(attn_weights.dtype).min)
+                )
 
             # upcast attention to fp32
-            attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+            attn_weights = nn.functional.softmax(
+                attn_weights, dim=-1, dtype=torch.float32
+            ).to(query_states.dtype)
             attn_output = torch.matmul(attn_weights, value_states)
 
         if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
@@ -142,12 +168,21 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
         bits: int = 4,
         disable_exllama=True,
         disable_exllamav2=False,
-        **kwargs
+        use_tritonv2=False,
+        **kwargs,
     ):
         """
         Replace all LlamaAttention modules with QuantLlamaAttention modules, fusing the q, k, v projections.
         """
-        QuantLinear = dynamically_import_QuantLinear(use_triton=use_triton, desc_act=desc_act, group_size=group_size, bits=bits, disable_exllama=disable_exllama, disable_exllamav2=disable_exllamav2)
+        QuantLinear = dynamically_import_QuantLinear(
+            use_triton=use_triton,
+            desc_act=desc_act,
+            group_size=group_size,
+            bits=bits,
+            disable_exllama=disable_exllama,
+            disable_exllamav2=disable_exllamav2,
+            use_tritonv2=use_tritonv2,
+        )
 
         for name, m in model.named_modules():
             if not isinstance(m, LlamaAttention):
@@ -157,7 +192,9 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
             k_proj = m.k_proj
             v_proj = m.v_proj
 
-            qweights = torch.cat([q_proj.qweight, k_proj.qweight, v_proj.qweight], dim=1)
+            qweights = torch.cat(
+                [q_proj.qweight, k_proj.qweight, v_proj.qweight], dim=1
+            )
             qzeros = torch.cat([q_proj.qzeros, k_proj.qzeros, v_proj.qzeros], dim=1)
             scales = torch.cat([q_proj.scales, k_proj.scales, v_proj.scales], dim=1)
 
@@ -166,13 +203,19 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
                     # TODO: support it. The issue lies maybe in the line:
                     # int groups = qzeros.size(0);
                     # in exllama_ext.cpp
-                    raise ValueError("Exllama kernel does not support query/key/value fusion with act-order. Please either use inject_fused_attention=False or disable_exllama=True.")
+                    raise ValueError(
+                        "Exllama kernel does not support query/key/value fusion with act-order. Please either use inject_fused_attention=False or disable_exllama=True."
+                    )
                 else:
                     g_idx = None
             else:
                 g_idx = torch.cat([q_proj.g_idx, k_proj.g_idx, v_proj.g_idx], dim=0)
-            
-            bias = torch.cat([q_proj.bias, k_proj.bias, v_proj.bias], dim=0) if q_proj.bias is not None else None
+
+            bias = (
+                torch.cat([q_proj.bias, k_proj.bias, v_proj.bias], dim=0)
+                if q_proj.bias is not None
+                else None
+            )
 
             qlinear_args = (
                 q_proj.bits,
@@ -192,19 +235,26 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
             qkv_layer.scales = scales
             qkv_layer.g_idx = g_idx
             qkv_layer.bias = bias
-            
+
             # Introduced in Transformers 4.36
             layer_idx = None
             if hasattr(m, "layer_idx"):
                 layer_idx = m.layer_idx
-            attn = cls(m.hidden_size, m.num_heads, qkv_layer, m.o_proj, m.rotary_emb, layer_idx=layer_idx)
+            attn = cls(
+                m.hidden_size,
+                m.num_heads,
+                qkv_layer,
+                m.o_proj,
+                m.rotary_emb,
+                layer_idx=layer_idx,
+            )
 
-            if '.' in name:
-                parent_name = name.rsplit('.', 1)[0]
-                child_name = name[len(parent_name) + 1:]
+            if "." in name:
+                parent_name = name.rsplit(".", 1)[0]
+                child_name = name[len(parent_name) + 1 :]
                 parent = model.get_submodule(parent_name)
             else:
-                parent_name = ''
+                parent_name = ""
                 parent = model
                 child_name = name
 

--- a/auto_gptq/nn_modules/qlinear/qlinear_tritonv2.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_tritonv2.py
@@ -1,0 +1,227 @@
+import math
+from logging import getLogger
+
+import numpy as np
+import torch
+import torch.nn as nn
+import transformers
+
+from ..triton_utils.mixin import TritonModuleMixin
+
+logger = getLogger(__name__)
+
+try:
+    from ..triton_utils.dequant import QuantLinearFunction, quant_matmul_248
+except ImportError as triton_import_exception:
+
+    def error_raiser_triton(*args, **kwargs):
+        raise ValueError(
+            f"Trying to use the triton backend, but could not import triton dependencies with the following error: {triton_import_exception}"
+        )
+
+    class FakeTriton:
+        def __getattr__(self, name):
+            raise ImportError(
+                f"Trying to use the triton backend, but could not import triton dependencies with the following error: {triton_import_exception}"
+            )
+
+    quant_matmul_248 = error_raiser_triton
+    QuantLinearFunction = FakeTriton
+    QuantLinearInferenceOnlyFunction = FakeTriton
+
+
+class QuantLinear(nn.Module, TritonModuleMixin):
+    QUANT_TYPE = "triton"
+
+    def __init__(
+        self, bits, group_size, infeatures, outfeatures, bias, trainable=False, **kwargs
+    ):
+        super().__init__()
+        if bits not in [2, 4, 8]:
+            raise NotImplementedError("Only 2,4,8 bits are supported.")
+        if infeatures % 32 != 0 or outfeatures % 32 != 0:
+            raise NotImplementedError(
+                "in_feature and out_feature must be divisible by 32."
+            )
+        self.infeatures = infeatures
+        self.outfeatures = outfeatures
+        self.bits = bits
+        self.group_size = group_size if group_size != -1 else infeatures
+        self.maxq = 2**self.bits - 1
+
+        self.register_buffer(
+            "qweight",
+            torch.zeros((infeatures // 32 * self.bits, outfeatures), dtype=torch.int32),
+        )
+        self.register_buffer(
+            "qzeros",
+            torch.zeros(
+                (
+                    math.ceil(infeatures / self.group_size),
+                    outfeatures // 32 * self.bits,
+                ),
+                dtype=torch.int32,
+            ),
+        )
+        self.register_buffer(
+            "scales",
+            torch.zeros(
+                (math.ceil(infeatures / self.group_size), outfeatures),
+                dtype=torch.float16,
+            ),
+        )
+        self.register_buffer(
+            "g_idx",
+            torch.tensor(
+                [i // self.group_size for i in range(infeatures)], dtype=torch.int32
+            ),
+        )
+        if bias:
+            self.register_buffer(
+                "bias", torch.zeros((outfeatures), dtype=torch.float16)
+            )
+        else:
+            self.bias = None
+
+        self.trainable = trainable
+
+    def post_init(self):
+        pass
+
+    def pack(self, linear, scales, zeros, g_idx=None):
+        W = linear.weight.data.clone()
+        if isinstance(linear, nn.Conv2d):
+            W = W.flatten(1)
+        if isinstance(linear, transformers.pytorch_utils.Conv1D):
+            W = W.t()
+
+        self.g_idx = g_idx.clone() if g_idx is not None else self.g_idx
+
+        scales = scales.t().contiguous()
+        zeros = zeros.t().contiguous()
+        scale_zeros = zeros * scales
+        self.scales = scales.clone().half()
+        if linear.bias is not None:
+            self.bias = linear.bias.clone().half()
+
+        intweight = []
+        for idx in range(self.infeatures):
+            intweight.append(
+                torch.round(
+                    (W[:, idx] + scale_zeros[self.g_idx[idx]])
+                    / self.scales[self.g_idx[idx]]
+                ).to(torch.int)[:, None]
+            )
+        intweight = torch.cat(intweight, dim=1)
+        intweight = intweight.t().contiguous()
+        intweight = intweight.numpy().astype(np.uint32)
+
+        i = 0
+        row = 0
+        qweight = np.zeros(
+            (intweight.shape[0] // 32 * self.bits, intweight.shape[1]), dtype=np.uint32
+        )
+        while row < qweight.shape[0]:
+            if self.bits in [2, 4, 8]:
+                for j in range(i, i + (32 // self.bits)):
+                    qweight[row] |= intweight[j] << (self.bits * (j - i))
+                i += 32 // self.bits
+                row += 1
+            else:
+                raise NotImplementedError("Only 2,4,8 bits are supported.")
+
+        qweight = qweight.astype(np.int32)
+        self.qweight = torch.from_numpy(qweight)
+
+        zeros -= 1
+        zeros = zeros.numpy().astype(np.uint32)
+        qzeros = np.zeros(
+            (zeros.shape[0], zeros.shape[1] // 32 * self.bits), dtype=np.uint32
+        )
+        i = 0
+        col = 0
+        while col < qzeros.shape[1]:
+            if self.bits in [2, 4, 8]:
+                for j in range(i, i + (32 // self.bits)):
+                    qzeros[:, col] |= zeros[:, j] << (self.bits * (j - i))
+                i += 32 // self.bits
+                col += 1
+            else:
+                raise NotImplementedError("Only 2,4,8 bits are supported.")
+
+        qzeros = qzeros.astype(np.int32)
+        self.qzeros = torch.from_numpy(qzeros)
+
+    def forward(self, x):
+        out_shape = x.shape[:-1] + (self.outfeatures,)
+        quant_linear_fn = QuantLinearFunction  
+            #if self.trainable else QuantLinearInferenceOnlyFunction
+        
+        out = quant_linear_fn.apply(
+            x.reshape(-1, x.shape[-1]),
+            self.qweight,
+            self.scales,
+            self.qzeros,
+            self.g_idx,
+            self.bits,
+            self.maxq,
+        )
+        out = out.half().reshape(out_shape)
+        out = out + self.bias if self.bias is not None else out
+        return out
+
+    @classmethod
+    def warmup(cls, model, transpose=False, seqlen=2048):
+        """
+        Pre-tunes the quantized kernel
+        """
+        from tqdm import tqdm
+
+        kn_values = {}
+
+        for _, m in model.named_modules():
+            if not isinstance(m, cls):
+                continue
+
+            k = m.infeatures
+            n = m.outfeatures
+
+            if (k, n) not in kn_values:
+                kn_values[(k, n)] = (
+                    m.qweight,
+                    m.scales,
+                    m.qzeros,
+                    m.g_idx,
+                    m.bits,
+                    m.maxq,
+                )
+
+        logger.info(f"Found {len(kn_values)} unique KN Linear values.")
+        logger.info("Warming up autotune cache ...")
+        with torch.no_grad():
+            for m in tqdm(range(0, math.ceil(math.log2(seqlen)) + 1)):
+                m = 2**m
+                for (k, n), (
+                    qweight,
+                    scales,
+                    qzeros,
+                    g_idx,
+                    bits,
+                    maxq,
+                ) in kn_values.items():
+                    if transpose:
+                        a = torch.randn(m, k, dtype=torch.float16, device=model.device)
+                        quant_matmul_248(a, qweight, scales, qzeros, g_idx, bits, maxq)
+                        a = torch.randn(m, n, dtype=torch.float16, device=model.device)
+                        transpose_quant_matmul_248(
+                            a, qweight, scales, qzeros, g_idx, bits, maxq
+                        )
+                    else:
+                        a = torch.randn(m, k, dtype=torch.float16, device=model.device)
+                        quant_matmul_inference_only_248(
+                            a, qweight, scales, qzeros, g_idx, bits, maxq
+                        )
+        del kn_values
+
+
+__all__ = ["QuantLinear"]

--- a/auto_gptq/nn_modules/triton_utils/dequant.py
+++ b/auto_gptq/nn_modules/triton_utils/dequant.py
@@ -84,8 +84,11 @@ def dequant_kernel_248(
     tl.store(out_ptr + (x_index), weights, mask=xmask)
 
 
-def dequant248(qweight, scales, qzeros, g_idx, bits, maxq=None, X_BLOCK=1024):
-    # elements_per_feature = 32 // bits
+def dequant248(qweight, scales, qzeros, g_idx, bits, maxq=None):
+    """
+    Launcher for triton dequant kernel.  Only valid for bits = 2, 4, 8
+    """
+
     num_groups = scales.shape[0]
     outfeatures = scales.shape[1]
     infeatures = g_idx.shape[0]
@@ -106,7 +109,6 @@ def dequant248(qweight, scales, qzeros, g_idx, bits, maxq=None, X_BLOCK=1024):
         bits=bits,
         outfeatures=outfeatures,
         num_groups=num_groups,
-        # X_BLOCK=X_BLOCK,
     )
     return out
 

--- a/auto_gptq/nn_modules/triton_utils/dequant.py
+++ b/auto_gptq/nn_modules/triton_utils/dequant.py
@@ -1,0 +1,140 @@
+import triton
+
+import triton.language as tl
+from torch.cuda.amp import custom_bwd, custom_fwd
+import torch
+import itertools
+def make_dequant_configs(block_sizes, num_warps):
+    configs = []
+    for bs, ws in itertools.product(block_sizes, num_warps):
+        configs.append(triton.Config({"X_BLOCK": bs}, num_warps=ws))
+        
+DEFAULT_DEQUANT_CONFIGS = make_dequant_configs([128, 256, 512, 1024], [4, 8])
+@triton.jit
+def dequant_kernel_248(
+    g_idx_ptr,
+    scales_ptr,
+    qweight_ptr,
+    qzeros_ptr,
+    out_ptr,
+    numels,
+    maxq: tl.constexpr,
+    bits: tl.constexpr,
+    outfeatures: tl.constexpr,
+    num_groups: tl.constexpr,
+    X_BLOCK: tl.constexpr,
+):
+    # Block indexing
+    xoffset = tl.program_id(0) * X_BLOCK
+    x_index = xoffset + tl.arange(0, X_BLOCK)
+    xmask = x_index < numels
+    row_idx = x_index // outfeatures  
+    col_idx = x_index % outfeatures  
+
+    elements_per_feature: tl.constexpr = 32 // bits
+
+    # Load parameters
+    g_idx = tl.load(
+        g_idx_ptr + (row_idx), None, eviction_policy="evict_last"
+    )  
+    qweights = tl.load(
+        qweight_ptr + (col_idx + (outfeatures * (row_idx // elements_per_feature))),
+        None,
+    )  
+
+    wf_weights = (row_idx % elements_per_feature) * bits
+
+    wf_zeros = (col_idx % elements_per_feature) * bits
+    tl.static_print("wf_zeros shape: ", wf_zeros.shape)
+
+    tmp1 = g_idx + num_groups  
+    tmp2 = g_idx < 0
+    tl.device_assert(g_idx >= 0, "index out of bounds: 0 <= tmp0 < 0")
+    groups = tl.where(tmp2, tmp1, g_idx)  # tmp3 are g_idx
+
+    scales = tl.load(scales_ptr + (col_idx + (outfeatures * groups)), None).to(
+        tl.float32
+    )  
+
+    # Unpack weights
+    weights = qweights >> wf_weights  # bit shift qweight
+    
+    weights = weights & maxq
+
+    # Unpack zeros
+    qzero_ncols: tl.constexpr = outfeatures // elements_per_feature
+    qzeros = tl.load(
+        qzeros_ptr + ((qzero_ncols * groups) + (col_idx // elements_per_feature)),
+        None,
+        eviction_policy="evict_last",  
+    )
+    zeros = qzeros >> wf_zeros  
+    zeros = zeros & maxq  
+
+    # Dequantize
+    zeros = zeros + 1  
+    weights = weights - zeros  
+    weights = weights.to(tl.float32)
+    weights = scales * weights 
+
+    tl.store(out_ptr + (x_index), weights, mask=xmask)  
+
+
+def dequant248(qweight, scales, qzeros, g_idx, bits, maxq=None, X_BLOCK=1024):
+    # elements_per_feature = 32 // bits
+    num_groups = scales.shape[0]
+    outfeatures = scales.shape[1]
+    infeatures = g_idx.shape[0]
+
+    out = torch.empty((infeatures, outfeatures), device="cuda", dtype=torch.float16)
+    numels = out.numel()
+    maxq = 2**bits - 1 if maxq is None else maxq
+    grid = lambda meta: (triton.cdiv(numels, meta["X_BLOCK"]),)
+
+    dequant_kernel_248[grid](
+        g_idx,
+        scales,
+        qweight,
+        qzeros,
+        out,
+        numels,
+        maxq=maxq,
+        bits=bits,
+        outfeatures=outfeatures,
+        num_groups=num_groups,
+        X_BLOCK=X_BLOCK,
+    )
+    return out
+
+
+
+def quant_matmul_248(
+    input, qweight, scales, qzeros, g_idx, bits, maxq=None, transpose=False
+):
+    W = dequant248(qweight, scales, qzeros, g_idx, bits, maxq=maxq)
+    if transpose:
+        return input @ W.t()
+    return input @ W
+
+
+class QuantLinearFunction(torch.autograd.Function):
+    @staticmethod
+    @custom_fwd
+    def forward(ctx, input, qweight, scales, qzeros, g_idx, bits, maxq):
+        output = quant_matmul_248(input, qweight, scales, qzeros, g_idx, bits, maxq)
+        ctx.save_for_backward(qweight, scales, qzeros, g_idx)
+        ctx.bits, ctx.maxq = bits, maxq
+        return output
+
+    @staticmethod
+    @custom_bwd
+    def backward(ctx, grad_output):
+        qweight, scales, qzeros, g_idx = ctx.saved_tensors
+        bits, maxq = ctx.bits, ctx.maxq
+        grad_input = None
+
+        if ctx.needs_input_grad[0]:
+            grad_input = quant_matmul_248(
+                grad_output, qweight, scales, qzeros, g_idx, bits, maxq, transpose=True
+            )
+        return grad_input, None, None, None, None, None, None

--- a/tests/benchmark_qlinear.py
+++ b/tests/benchmark_qlinear.py
@@ -1,0 +1,254 @@
+import argparse
+import itertools
+import os
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import torch
+import triton
+
+from auto_gptq.modeling._utils import autogptq_post_init
+from auto_gptq.nn_modules.qlinear import (
+    qlinear_cuda,
+    qlinear_cuda_old,
+    qlinear_exllama,
+    qlinear_exllamav2,
+    qlinear_triton,
+    qlinear_tritonv2,
+)
+
+COLORS = itertools.cycle(plt.rcParams["axes.prop_cycle"].by_key()["color"])
+STYLES = itertools.cycle(["solid", "dashed", "dashdot", "dotted"])
+
+
+@dataclass
+class GPTQState:
+    infeatures: int
+    outfeatures: int
+    qweight: torch.Tensor
+    qzeros: torch.Tensor
+    scales: torch.Tensor
+    g_idx: torch.Tensor
+    wf: torch.Tensor
+    bits: int
+    maxq: int
+    group_size: int
+
+
+def down_load_test_modules(save_dir="./fixtures"):
+
+    from transformers import AutoModelForCausalLM
+
+    dtype = torch.float16
+
+    mistal_model = AutoModelForCausalLM.from_pretrained(
+        "TheBloke/Mistral-7B-v0.1-GPTQ",
+        torch_dtype=dtype,
+        device_map="auto",
+    )
+    llama_model = AutoModelForCausalLM.from_pretrained(
+        "TheBloke/Llama-2-7B-GPTQ",
+        torch_dtype=dtype,
+        device_map="auto",
+    )
+
+    for model in [mistal_model, llama_model]:
+        model_name = model.model.__class__.__name__
+        torch.save(
+            model.model.layers[0].self_attn,
+            f"./{save_dir}/gptq_{model_name}_self_attn0_layer0.pt",
+        )
+        torch.save(
+            model.model.layers[0].mlp, f"./{save_dir}/gptq_{model_name}_mlp_layer0.pt"
+        )
+
+
+def make_perf_report(
+    x_names,
+    x_vals,
+    line_vals,
+    title="Qlinear Bench",
+    ylabel="ms",
+    line_names=None,
+    x_log=True,
+):
+    line_styles = [(next(COLORS), next(STYLES)) for _ in range(len(line_vals))]
+
+    bench = triton.testing.Benchmark(
+        x_names=x_names,  # Argument names to use as an x-axis for the plot.
+        x_vals=x_vals,  # Different possible values for `x_name`.
+        x_log=x_log,  # x axis is logarithmic.
+        line_arg="kernel",
+        # Argument name whose value corresponds to a different line in the plot.
+        line_vals=line_vals,  # , "fast"],  # Possible values for `line_arg`.
+        line_names=(
+            line_names if line_names else line_vals
+        ),  # , "fast"],  # Label name for the lines.
+        styles=line_styles,  # Line styles.
+        ylabel=ylabel,  # Label name for the y-axis.
+        plot_name=title,  # Name for the plot. Used also as a file name for saving the plot.
+        args={},  # Values for function arguments not in `x_names` and `y_name`.
+    )
+    return triton.testing.perf_report(bench)
+
+
+FIXTURES_PATH = Path(__file__).parent.absolute() / "fixtures"
+
+
+def get_qstate(fixtures_path, model="llama", module="self_attn", layer="q_proj"):
+    module_paths = os.listdir(fixtures_path)
+    try:
+        module_path = next(
+            p for p in module_paths if (model in p.lower() and module in p.lower())
+        )
+    except:
+        raise ValueError(f"Could not find {model} {module} in {module_paths}")
+    print(f"Loading {module_path}")
+
+    module = torch.load(os.path.join(fixtures_path, module_path))
+    layer = getattr(module, layer)
+    return GPTQState(
+        infeatures=layer.infeatures,
+        outfeatures=layer.outfeatures,
+        qweight=layer.qweight.cuda(),
+        qzeros=layer.qzeros.cuda(),
+        scales=layer.scales.cuda(),
+        g_idx=layer.g_idx.cuda(),
+        wf=layer.wf.cuda(),
+        bits=layer.bits,
+        maxq=layer.maxq,
+        group_size=layer.group_size,
+    )
+
+
+def make_data(batch_size, seqlen, hidden_size, dtype=torch.float16, seed=3407):
+    torch.manual_seed(seed)
+    X = torch.randn(batch_size, seqlen, hidden_size, dtype=dtype).cuda()
+    return X
+
+
+BENCHMARK_QLAYER_NAMES = [
+    "qlinear_cuda_old",
+    "qlinear_cuda",
+    "qlinear_triton",
+    "qlinear_tritonv2",
+    "qlinear_exllama",
+    "qlinear_exllamav2",
+]
+BENCHMARK_QLAYER_TYPES = [
+    qlinear_cuda_old,
+    qlinear_cuda,
+    qlinear_triton,
+    qlinear_tritonv2,
+    qlinear_exllama,
+    qlinear_exllamav2,
+]
+
+
+def get_qlayers(
+    qstate: GPTQState,
+    max_seq_len,
+    layer_names=BENCHMARK_QLAYER_NAMES,
+    layer_types=BENCHMARK_QLAYER_TYPES,
+):
+    qlayers = {}
+    for linear_name, linear_cls in zip(layer_names, layer_types):
+        linear = linear_cls.QuantLinear(
+            bits=qstate.bits,
+            group_size=qstate.group_size,
+            infeatures=qstate.infeatures,
+            outfeatures=qstate.outfeatures,
+            bias=False,
+        )
+        linear.qweight = qstate.qweight
+        linear.qzeros = qstate.qzeros
+        linear.scales = qstate.scales
+        linear.g_idx = qstate.g_idx
+        linear.wf = qstate.wf
+        linear.maxq = qstate.maxq
+        if isinstance(linear, qlinear_exllama.QuantLinear) or isinstance(
+            linear, qlinear_exllamav2.QuantLinear
+        ):
+            linear = autogptq_post_init(
+                linear, use_act_order=False, max_input_length=max_seq_len
+            )
+        qlayers[linear_name] = linear
+
+    return qlayers
+
+
+def get_diff(a, ref):
+    eps = 1e-6
+    return f"Maxdiff: {(a - ref).abs().max()}, Mean relative diff: {((a - ref).abs() / (ref.abs() + eps)).mean()}"
+
+
+def run_check(X, qlayers: dict):
+    outs = {}
+    for qname, qlayer in qlayers.items():
+        outs[qname] = qlayer(X)
+    ref = outs.pop("qlinear_cuda_old")
+
+    for name, test_out in outs.items():
+        print(f"qlinear_cuda_old vs {name}: {get_diff(ref, test_out)}")
+
+
+def benchmark(seqlen, kernel, qstate: GPTQState = None, check=False):
+    qlayers = get_qlayers(qstate, max_seq_len=seqlen)
+    X = make_data(1, seqlen, qstate.infeatures, dtype=torch.float16)
+    quantiles = [0.5, 0.2, 0.8]
+    if check:
+        run_check(X, qlayers)
+
+    fn = lambda: qlayers[kernel](X)
+    quants = triton.testing.do_bench(fn, quantiles=quantiles)
+    return quants
+
+
+def run_bench(
+    qstate: GPTQState,
+    seqlen=[128, 256, 512, 1024, 2048],
+    check=False,
+    outdir="qlinear_bench",
+):
+    x_names = ["seqlen"]
+    x_vals = seqlen
+    line_vals = BENCHMARK_QLAYER_NAMES
+
+    reporter = make_perf_report(x_names=x_names, x_vals=x_vals, line_vals=line_vals)
+    bench = partial(benchmark, qstate=qstate, check=check)
+    runner = reporter(bench)
+
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+    runner.run(print_data=True, save_path=outdir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "--fixtures_path",
+        type=str,
+        default=FIXTURES_PATH,
+        help="Path to saved GPTQ pre-quantized modules.  Defaults to fixtures directory with self_attn and mlp modules from layer 0"
+        "of TheBloke/Llama-7B-GPTQ and TheBloke/Mistral-7B-v0.1-GPTQ"
+        "Download first by running download_test_modules function in this file",
+    )
+    parser.add_argument("--model", type=str, default="llama", help="Saved model name")
+    parser.add_argument(
+        "--module",
+        type=str,
+        default="self_attn",
+        help="Module name for benchmarking (must be saved in fixtures path)",
+    )
+    parser.add_argument(
+        "--layer", type=str, default="q_proj", help="Layer name in module to benchmark"
+    )
+    args = parser.parse_args()
+    qstate: GPTQState = get_qstate(
+        args.fixtures_path, args.model, args.module, args.layer
+    )
+    run_bench(qstate)

--- a/tests/benchmark_qlinear.py
+++ b/tests/benchmark_qlinear.py
@@ -243,6 +243,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--layer", type=str, default="q_proj", help="Layer name in module to benchmark"
     )
+    parser.add_argument(
+        "--check", action="store_true", help="Check outputs against qlinear_cuda_old"
+    )
     args = parser.parse_args()
     fixtures_path = args.fixtures_path
     if not os.path.exists(fixtures_path):
@@ -250,4 +253,4 @@ if __name__ == "__main__":
         download_test_modules(fixtures_path)
 
     qstate: GPTQState = get_qstate(fixtures_path, args.model, args.module, args.layer)
-    run_bench(qstate)
+    run_bench(qstate, check=args.check)

--- a/tests/benchmark_tritonv2_integration.py
+++ b/tests/benchmark_tritonv2_integration.py
@@ -24,6 +24,7 @@ def get_diff(a, ref):
     return f"Maxdiff: {(a - ref).abs().max()}, Mean relative diff: {((a - ref).abs() / (ref.abs() + eps)).mean()}"
 
 
+#Adapted from https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/utils/benchmark.py
 def benchmark_forward(
     fn,
     *inputs,
@@ -312,66 +313,66 @@ def run_test(model_id, use_tritonv2=True, batch_size=1, max_seq_len=10, seed=340
             else:
                 ref_out = getattr(ref_mlp, k)(test_data)
                 test_out = getattr(test_mlp, k)(test_data)
-                print(
-                    f"Layer {i} mlp {k}: diff={get_diff(test_out, ref_out)}"
-                )  # , get_diff(test_out.logits, ref_out.logits)
+            print(
+                f"Layer {i} mlp {k}: diff={get_diff(test_out, ref_out)}"
+            )  # , get_diff(test_out.logits, ref_out.logits)
         print()
     # torch.testing.assert_allclose(test_out.logits, ref_out.logits, rtol=3e-5, atol=2e-2)
 
 
-get_hf_model()
+# get_hf_model()
 
-# if __name__ == "__main__":
-#     parser = argparse.ArgumentParser(
-#         formatter_class=argparse.ArgumentDefaultsHelpFormatter
-#     )
-#     parser.add_argument("--model_id", type=str, default=MODEL_ID, help="Model ID")
-#     parser.add_argument(
-#         "--max_seq_len",
-#         type=int,
-#         default=MAX_SEQ_LEN,
-#         help="Max sequence length for benchmarking",
-#     )
-#     parser.add_argument(
-#         "--batch_size", type=int, default=BATCH_SIZE, help="Batch size for benchmarking"
-#     )
-#     parser.add_argument("--use_tritonv2", action="store_true", help="Use Tritonv2")
-#     parser.add_argument(
-#         "--benchmark_kernel",
-#         type=str,
-#         default="tritonv2",
-#         choices=["triton", "tritonv2", "exllama", "exllamav2", "default"],
-#         help="Run benchmark",
-#     )
-#     parser.add_argument(
-#         "--test", action="store_true", help="Test triton vs triton-v2 outputs"
-#     )
-#     parser.add_argument(
-#         "--test_kernel",
-#         type=str,
-#         default="tritonv2",
-#         choices=["triton", "tritonv2"],
-#         help="Whether to compare triton or tritonv2 against cuda-old ref",
-#     )
-#     args = parser.parse_args()
-#     if args.test:
-#         use_tritonv2 = True if args.test_kernel == "tritonv2" else False
-#         use_triton = not use_tritonv2
-#         print(
-#             "Testing qlinear outputs between ref (cuda_old) vs {}".format(
-#                 "Tritonv2" if use_tritonv2 else "Triton"
-#             )
-#         )
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--model_id", type=str, default=MODEL_ID, help="Model ID")
+    parser.add_argument(
+        "--max_seq_len",
+        type=int,
+        default=MAX_SEQ_LEN,
+        help="Max sequence length for benchmarking",
+    )
+    parser.add_argument(
+        "--batch_size", type=int, default=BATCH_SIZE, help="Batch size for benchmarking"
+    )
+    parser.add_argument("--use_tritonv2", action="store_true", help="Use Tritonv2")
+    parser.add_argument(
+        "--benchmark_kernel",
+        type=str,
+        default="tritonv2",
+        choices=["triton", "tritonv2", "exllama", "exllamav2", "default"],
+        help="Run benchmark",
+    )
+    parser.add_argument(
+        "--test", action="store_true", help="Test triton vs triton-v2 outputs"
+    )
+    parser.add_argument(
+        "--test_kernel",
+        type=str,
+        default="tritonv2",
+        choices=["triton", "tritonv2"],
+        help="Whether to compare triton or tritonv2 against cuda-old ref",
+    )
+    args = parser.parse_args()
+    if args.test:
+        use_tritonv2 = True if args.test_kernel == "tritonv2" else False
+        use_triton = not use_tritonv2
+        print(
+            "Testing qlinear outputs between ref (cuda_old) vs {}".format(
+                "Tritonv2" if use_tritonv2 else "Triton"
+            )
+        )
 
-#         run_test(
-#             args.model_id,
-#             use_tritonv2=use_tritonv2,
-#         )
-#     else:
-#         print("Running benchmark...")
-#         run_benchmark(
-#             args.model_id,
-#             kernel=args.benchmark_kernel,
-#             max_seq_len=args.max_seq_len,
-#             batch_size=args.batch_size,
-#         )
+        run_test(
+            args.model_id,
+            use_tritonv2=use_tritonv2,
+        )
+    else:
+        print("Running benchmark...")
+        run_benchmark(
+            args.model_id,
+            kernel=args.benchmark_kernel,
+            max_seq_len=args.max_seq_len,
+            batch_size=args.batch_size,
+        )

--- a/tests/run_triton_benchmark.sh
+++ b/tests/run_triton_benchmark.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+kernels=("default" "triton" "tritonv2" "exllama" "exllamav2")
+
+for kernel in "${kernels[@]}"; do
+    CMD="python benchmark_tritonv2_integration.py --benchmark_kernel=$kernel 2>&1 | tee ${kernel}_bench.txt"
+    echo $CMD
+    eval $CMD
+done


### PR DESCRIPTION
## Faster Triton Dequant Kernel and QuantLinear

Add a `triton` `Quantlinear` layer (`qlinear_tritonv2`) that uses a refactored, faster dequantization kernel.

The new [kernel](https://github.com/jeromeku/AutoGPTQ/blob/e218ab5dda4abff14f3fdd40533bb4ff69b18986/auto_gptq/nn_modules/triton_utils/dequant.py#L21) separates dequantization from matmul. When incorporated into a `QuantLinear` [layer](https://github.com/jeromeku/AutoGPTQ/blob/tritonv2/auto_gptq/nn_modules/qlinear/qlinear_tritonv2.py), performance is on par with `exllama` and `exllamav2` kernels in both layer-level and model-level benchmarks.

This kernel should enable faster `peft`-style fine-tuning of pre-quantized `GPTQ` models (e.g., see this [PR](https://github.com/unslothai/unsloth/pull/141)).

### Correctness

Comparing the outputs of `qlinear_tritonv2.QuantLinear` with `qlinear_cuda_old.QuantLinear` for the `self_attn` and `mlp` layers of pre-quantized `TheBloke/Llama-2-7B-GPTQ` gives errors similar to those of the original `qlinear_triton.QuantLinear` layer.

- `tritonv2` against `cuda_old`

```
    Layer 0 self_attn q_proj: diff=Maxdiff: 0.0078125, Mean relative diff: 0.00266265869140625
    Layer 0 self_attn k_proj: diff=Maxdiff: 0.0078125, Mean relative diff: 0.0026721954345703125
    Layer 0 self_attn v_proj: diff=Maxdiff: 0.001953125, Mean relative diff: 0.00232696533203125
    Layer 0 self_attn o_proj: diff=Maxdiff: 0.0078125, Mean relative diff: 0.0027675628662109375

    Layer 0 mlp gate_proj: diff=Maxdiff: 0.0078125, Mean relative diff: 0.0025005340576171875
    Layer 0 mlp up_proj: diff=Maxdiff: 0.00390625, Mean relative diff: 0.0029392242431640625
    Layer 0 mlp down_proj: diff=Maxdiff: 0.0078125, Mean relative diff: 0.0020275115966796875
```

- `triton` vs `cuda_old`

```
    Layer 0 self_attn q_proj: diff=Maxdiff: 0.0078125, Mean relative diff: 0.0026645660400390625
    Layer 0 self_attn k_proj: diff=Maxdiff: 0.0078125, Mean relative diff: 0.0026702880859375
    Layer 0 self_attn v_proj: diff=Maxdiff: 0.001953125, Mean relative diff: 0.00232696533203125
    Layer 0 self_attn o_proj: diff=Maxdiff: 0.0078125, Mean relative diff: 0.0027637481689453125

    Layer 0 mlp gate_proj: diff=Maxdiff: 0.0078125, Mean relative diff: 0.0025005340576171875
    Layer 0 mlp up_proj: diff=Maxdiff: 0.00390625, Mean relative diff: 0.0029392242431640625
    Layer 0 mlp down_proj: diff=Maxdiff: 0.0078125, Mean relative diff: 0.002025604248046875
```

**Repro**

```python
python benchmark_tritonv2_integration.py --test --test_kernel=tritonv2
python benchmark_tritonv2_integration.py --test --test_kernel=triton
```

### Qlinear Benchmarks

Benchmarking qlinear_tritonv2.QuantLinear against existing kernels using quantized state of `q_proj` of `layer 0` of `TheBloke/Llama-2-7b-GPTQ`:

_Median times (ms)_

```
   seqlen  qlinear_cuda_old  qlinear_cuda  qlinear_triton  qlinear_tritonv2  qlinear_exllama  qlinear_exllamav2
0   128.0          0.564224      0.771072        0.171008          0.124928         0.158720           0.161792
1   256.0          0.590848      0.806912        0.330752          0.160768         0.141312           0.144384
2   512.0          0.646144      0.861184        0.547840          0.210992         0.226304           0.228352
3  1024.0          0.800480      1.014784        0.952320          0.366480         0.347136           0.349184
4  2048.0          1.105408      1.324032        1.761856          0.684576         0.642048           0.637952
```

**Repro**

```python
python benchmark_qlinear.py
```

### Integration Benchmarks

We also see speedups running the model end-to-end with `qlinear_tritonv2.QuantLinear` using `torch.utils.benchmark.Timer.adaptive_autorange` to benchmark the forward pass of a model (results for `TheBloke/Llama-2-7b-GPTQ` shown below).

- `qlinear_cuda`

```
 Median: 816.35 ms
 IQR:    0.65 ms (815.93 to 816.58)
 4 measurements, 1 runs per measurement, 8 threads
```

- `qlinear_triton`

```
 Median: 1.46 s
  IQR:    0.00 s (1.46 to 1.47)
  4 measurements, 1 runs per measurement, 8 threads
```

- `qlinear_tritonv2`

```
  Median: 657.80 ms
  IQR:    1.53 ms (657.15 to 658.68)
  4 measurements, 1 runs per measurement, 8 threads
```

- `qlinear_exllama`

```
  Median: 633.93 ms
  IQR:    1.97 ms (633.19 to 635.16)
  4 measurements, 1 runs per measurement, 8 threads
```

- `qlinear_exllamav2`

```
  Median: 634.38 ms
  IQR:    1.64 ms (633.66 to 635.30)
  4 measurements, 1 runs per measurement, 8 threads

```

**Repro**

```python
python benchmark_tritonv2_integration.py --benchmark_kernel=tritonv2
```

Replace `benchmark_kernel` with desired kernel: `default`, `triton`, `tritonv2`, `exllama`, `exllamav2`.

Alternatively, run the following to benchmark all kernels and save results to `{kernel}_bench.txt`

```
chmod +x run_triton_benchmark.sh
./run_triton_benchmark.sh
```
@fxmarty 