### PR TITLE
Untie weights for safetensors serialization

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -123,7 +123,7 @@ class BaseQuantizeConfig(PushToHubMixin):
         field_names = [field.name for field in fields(cls)]
         with open(resolved_config_file, "r", encoding="utf-8") as f:
             args_from_json = json.load(f)
-            
+
             if transformers_config:
                 args_from_json = args_from_json["quantization_config"]
             
@@ -1029,7 +1029,6 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                     gptq_layers = set()
                     non_gptq_params = set()
                     with safe_open(model_save_name, framework="pt") as f:
-                        state_dict_keys = list(f.keys())
                         for state_dict_key in f.keys():
                             if "qweight" not in state_dict_key and "qzeros" not in state_dict_key and "scales" not in state_dict_key:
                                 non_gptq_params.add(state_dict_key)

--- a/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
@@ -22,7 +22,7 @@ import transformers
 logger = getLogger(__name__)
 
 try:
-    import marlin_cuda
+    import autogptq_marlin_cuda
 
     _marlin_available = True
 except ImportError:
@@ -40,7 +40,7 @@ def mul(A, B, C, s, workspace, thread_k=-1, thread_n=-1, sms=-1):
     @thread_n: `n` size of a thread_tile in `B` (can usually be left as auto -1)
     @sms: number of SMs to use for the kernel (can usually be left as auto -1)
     """
-    marlin_cuda.mul(A, B, C, s, workspace, thread_k, thread_n, sms)
+    autogptq_marlin_cuda.mul(A, B, C, s, workspace, thread_k, thread_n, sms)
 
 
 # Precompute permutations for Marlin weight and scale shuffling 

--- a/auto_gptq/utils/import_utils.py
+++ b/auto_gptq/utils/import_utils.py
@@ -44,7 +44,7 @@ except Exception as e:
     QIGEN_EXCEPTION = e
 
 try:
-    import marlin_cuda
+    import autogptq_marlin_cuda
 
     MARLIN_AVAILABLE = True
 except Exception as e:

--- a/auto_gptq/utils/modeling_utils.py
+++ b/auto_gptq/utils/modeling_utils.py
@@ -1,0 +1,26 @@
+import functools
+
+def recurse_getattr(obj, attr: str):
+    """
+    Recursive `getattr`.
+
+    Args:
+        obj:
+            A class instance holding the attribute.
+        attr (`str`):
+            The attribute that is to be retrieved, e.g. 'attribute1.attribute2'.
+    """
+
+    def _getattr(obj, attr):
+        return getattr(obj, attr)
+
+    return functools.reduce(_getattr, [obj] + attr.split("."))
+
+
+def recurse_setattr(module, name, value):
+    """A function to recursively set attributes to a module."""
+    if "." not in name:
+        setattr(module, name, value)
+    else:
+        name, rest = name.split(".", 1)
+        recurse_setattr(getattr(module, name), rest, value)

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ if BUILD_CUDA_EXT:
 
             extensions.append(
                 cpp_extension.CUDAExtension(
-                    'marlin_cuda',
+                    'autogptq_marlin_cuda',
                     [
                         'autogptq_extension/marlin/marlin_cuda.cpp',
                         'autogptq_extension/marlin/marlin_cuda_kernel.cu'


### PR DESCRIPTION
Safetensors is unable to handle tied weights as reported in https://github.com/AutoGPTQ/AutoGPTQ/pull/524/files#r1474229087 & https://github.com/huggingface/safetensors/issues/202