### PR TITLE
Support CPU only quantization.

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -365,7 +365,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         layers = get_module_by_name_prefix(self.model, self.layers_block_name)
 
         force_layer_back_to_cpu = False
-        if get_device(layers[0]) == CPU:
+        if get_device(layers[0]) == CPU and torch.cuda.is_available():
             layers[0] = layers[0].to(CUDA_0)
             force_layer_back_to_cpu = True
 
@@ -400,7 +400,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             if module is not None:
                 move_to_device(module, ori_outside_layer_module_devices[module_name])
 
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
         inside_layer_modules = self.inside_layer_modules
         if not self.quantize_config.true_sequential:
@@ -410,7 +411,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             logger.info(f"Start quantizing layer {i + 1}/{len(layers)}")
             layer = layers[i]
             force_layer_back_to_cpu = False
-            if get_device(layer) == CPU:
+            if get_device(layer) == CPU and torch.cuda.is_available():
                 move_to_device(layer, CUDA_0)
                 force_layer_back_to_cpu = True
             cur_layer_device = get_device(layer)
@@ -489,7 +490,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             del gptq
             del layer_inputs
             layer_inputs, layer_outputs = layer_outputs, []
-            torch.cuda.empty_cache()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
 
         pack_model(
             model=self.model,
@@ -509,7 +511,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
 
         self._quantized = True
 
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     @property
     def device(self):
@@ -712,9 +715,6 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
     ):
         """load un-quantized pretrained model to cpu"""
 
-        if not torch.cuda.is_available():
-            raise EnvironmentError("Load pretrained model to do quantization requires CUDA available.")
-
         def skip(*args, **kwargs):
             pass
 
@@ -781,7 +781,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             model_init_kwargs["device_map"] = None
             model_init_kwargs["low_cpu_mem_usage"] = False
 
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
         merged_kwargs = {**model_init_kwargs, **cached_file_kwargs}
         model = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path, **merged_kwargs)

--- a/auto_gptq/quantization/gptq.py
+++ b/auto_gptq/quantization/gptq.py
@@ -166,7 +166,8 @@ class GPTQ:
                 logger.debug(torch.sum((self.layer(self.inp1) - self.out1) ** 2))
                 logger.debug(torch.sum(Losses))
 
-        torch.cuda.synchronize()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
         logger.info(f"duration: {(time.time() - tick)}")
         logger.info(f"avg loss: {torch.sum(Losses).item() / self.nsamples}")
 
@@ -200,7 +201,8 @@ class GPTQ:
         self.H = None
         self.Losses = None
         self.Trace = None
-        torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
 
 __all__ = ["GPTQ"]


### PR DESCRIPTION
The server CPU has many cores which can be used to quantize LLMs. This patch supports to quantize LLMs on CPU only with float data type.