### PR TITLE
Fix for fields being lists

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -94,6 +94,11 @@ class BaseQuantizeConfig(PushToHubMixin):
     def __post_init__(self):
         fields_info = fields(self)
 
+        for check_field in ['bits', 'group_size', 'damp_percent']:
+            if isinstance(self.__dict__[check_field], list) and \
+                  len(self.__dict__[check_field]) == 1:
+                self.__dict__[check_field] = self.__dict__[check_field][0]
+
         if self.bits not in fields_info[0].metadata["choices"]:
             raise ValueError(f"only support quantize to {fields_info[0].metadata['choices']} bits.")
         if self.group_size != -1 and self.group_size <= 0:


### PR DESCRIPTION
## Description

This fixes an error happening with [TheBloke/stablelm-zephyr-3b-GPTQ](https://huggingface.co/TheBloke/stablelm-zephyr-3b-GPTQ) model where certain fields are single element lists.

### How to test

I tested it through [lm-eval](https://github.com/EleutherAI/lm-evaluation-harness) on arc-challenge:

```bash
lm-eval --model hf --model_args pretrained=TheBloke/stablelm-zephyr-3b-GPTQ,trust_remote_code=True,autogptq=model.safetensors,quantization_config={'bits':4} --tasks arc_challenge --device cuda:0 --batch_size auto --output /tmp/results/stablelm-zephyr-3b-GPTQ
```