### PR TITLE
Explicitely check compute capability in marlin's QLinear

### DIFF
--- a/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
@@ -88,6 +88,12 @@ class QuantLinear(nn.Module):
 
     def __init__(self, bits, group_size, infeatures, outfeatures, bias, trainable=False, **kwargs):
         super().__init__()
+
+        if torch.version.hip:
+            raise ValueError("Can not use Marlin int4*fp16 kernel with AMD ROCm version of PyTorch as the kernel is not compatible. Please do not use `use_marlin=True` when using ROCm devices.")
+        if not torch.cuda.get_device_capability()[0] >= 8:
+            raise ValueError(f'Can not use Marlin int4*fp16 kernel with a device of compute capability {torch.cuda.get_device_capability()}, the minimum compute capability is 8.0 for Marlin kernel. Please do not use `use_marlin=True`, or please upgrade your GPU ("The more you buy, the more you save." - Taiwanese proverb).')
+
         if infeatures % 128 != 0 or outfeatures % 256 != 0:
             raise ValueError("`infeatures` must be divisible by 128 and `outfeatures` by 256.")
         if bits not in [4]:


### PR DESCRIPTION
Some people may use Marlin's QLinear without using the `from_quantized` method. Hence the check there as well.

Also fix an issue due to a transformers breaking backward compatibility issue https://github.com/huggingface/transformers/pull/29299