### PR TITLE
Removing Redundant 'scales' Assignment

### DIFF
--- a/auto_gptq/modeling/_utils.py
+++ b/auto_gptq/modeling/_utils.py
@@ -541,9 +541,6 @@ def unpack_awq(
     qweight = awq_qweight.cuda()
     qweight = qweight.T.contiguous()
 
-    scales = awq_scales
-    scales = scales.reshape(-1, 1, scales.shape[-1])
-
     infeatures = awq_qweight.shape[0]
 
     wf = torch.tensor(list(range(0, 32, bits)), dtype=torch.int32, device=qzeros.device).unsqueeze(0)


### PR DESCRIPTION
In `auto_gptq/modeling/_utils.py` removed redundant `scales` variable assignment as the first assignment is unused