### PR TITLE
Fix marlin quantization using BaseQuantizeConfig from _pretrained #581

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -501,6 +501,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             desc_act=self.quantize_config.desc_act,
             warmup_triton=autotune_warmup_after_quantized,
             force_layer_back_to_cpu=force_layer_back_to_cpu,
+            is_marlin_format=self.quantize_config.is_marlin_format,
         )
         if device_map:
             self.model = remove_hook_from_module(self.model, recurse=True)

--- a/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
@@ -169,8 +169,11 @@ class QuantLinear(nn.Module):
         q = torch.from_numpy(q.astype(np.int32)).to(w.device)
         self.B[:, :] = q.to(self.B.device)
         self.s[:, :] = s.to(self.s.device)
-        if self.bias is not None:
-            self.bias[:] = linear.bias.data.to(self.bias.device)
+        if linear.bias is not None:
+            if self.bias is not None:
+                self.bias[:] = linear.bias.data.to(self.bias.device)
+            else:
+                self.bias = linear.bias.clone()
 
     def forward(self, A):
         A = A.half()


### PR DESCRIPTION
Fix Issue #581

Main branch cannot perform marlin quantization as show in example below due to is_marlin_format not read/applied from quantization_config:

```
quantize_config = BaseQuantizeConfig(
    bits=4,  # quantize model to 4-bit
    group_size=128,  # it is recommended to set the value to 128
    desc_act=False,  # desc_act and group size only works on triton
    damp_percent=0.005,
    is_marlin_format=True
)
# load un-quantized model, the model will always be force loaded into cpu
model = AutoGPTQForCausalLM.from_pretrained(pretrained_model_dir, quantize_config=quantize_config)

# quantize model, the examples should be list of dict whose keys can only be "input_ids" and "attention_mask"
# with value under torch.LongTensor type.
model.quantize(traindataset, use_triton=False)

# save quantized model
model.save_quantized(quantized_model_dir)
```

Also fixed qlinear_marlin.py not correctly handling `linear.bias == None`. 

@chu-tianxiang  @fxmarty 