### PR TITLE
Add checkpoint_format to unify all current/future saved weight formats

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -980,7 +980,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
 
                 if use_marlin:
                     raise ValueError(
-                        "Tried to load an AWQ kernel with use_marlin=True. This is currently not supported. Please open an issue in AutoGPTQ repository."
+                        "Tried to load an AWQ model with use_marlin=True. This is currently not supported. Please open an issue in AutoGPTQ repository."
                     )
 
                 model_cache_name, is_cached = quantize_config.get_cache_file_path()
@@ -990,7 +990,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                     logger.info(f"Loading an AWQ model, detected a cached repacked weight at {model_save_name}.")
                 else:
                     logger.info(
-                        "Loading an AWQ model. This requires repacking the weights, and no repacking cached weight was found. Grab a coffee!"
+                        "Loading an AWQ model. This requires repacking the weights, and no cached repacked checkpoint was found. Grab a coffee!"
                     )
 
                     if "safetensors" not in model_save_name:

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -1,13 +1,10 @@
 import copy
-import json
 import logging
 import os
-from dataclasses import dataclass, field, fields
 from os.path import isdir, join
 from typing import Dict, List, Optional, Union
 
 import accelerate
-import huggingface_hub
 import torch
 import torch.nn as nn
 import transformers
@@ -22,14 +19,19 @@ from transformers.utils.generic import ContextManagers
 from transformers.utils.hub import (
     CommitOperationAdd,
     PushToHubMixin,
-    cached_file,
     create_commit,
     create_repo,
 )
 
 from ..nn_modules._fused_base import FusedBaseAttentionModule, FusedBaseMLPModule
 from ..nn_modules.qlinear import GeneralQuantLinear
-from ..quantization import GPTQ
+from ..quantization import GPTQ, BaseQuantizeConfig
+from ..quantization.config import (
+    CHECKPOINT_FORMAT,
+    CHECKPOINT_FORMAT_FIELD,
+    QUANT_METHOD_FIELD,
+    QUANTIZE_BLACK_LIST,
+)
 from ..utils.accelerate_utils import load_checkpoint_in_model
 from ..utils.data_utils import collate_data
 from ..utils.import_utils import (
@@ -73,131 +75,6 @@ logger.propagate = False
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
-SYNONYMS = {
-    "w_bit": "bits",
-    "q_group_size": "group_size",
-}
-
-
-@dataclass
-class BaseQuantizeConfig(PushToHubMixin):
-    bits: int = field(default=4, metadata={"choices": [2, 3, 4, 8]})
-    group_size: int = field(default=-1)
-    damp_percent: float = field(default=0.01)
-    desc_act: bool = field(default=True)
-    static_groups: bool = field(default=False)
-    sym: bool = field(default=True)
-    true_sequential: bool = field(default=True)
-    is_marlin_format: bool = field(default=False)
-    model_name_or_path: Optional[str] = field(default=None)
-    model_file_base_name: Optional[str] = field(default=None)
-    awq_gemm_checkpoint: Optional[bool] = field(default=False)
-
-    def __post_init__(self):
-        fields_info = fields(self)
-
-        if self.bits not in fields_info[0].metadata["choices"]:
-            raise ValueError(f"only support quantize to {fields_info[0].metadata['choices']} bits.")
-        if self.group_size != -1 and self.group_size <= 0:
-            raise ValueError("unless equal to -1, group_size must greater then 0.")
-        if not (0 < self.damp_percent < 1):
-            raise ValueError("damp_percent must between 0 and 1.")
-
-    def save_pretrained(self, save_dir: str, **kwargs):
-        with open(join(save_dir, "quantize_config.json"), "w", encoding="utf-8") as f:
-            json.dump(self.to_dict(), f, indent=2)
-
-    @classmethod
-    def from_pretrained(cls, save_dir: str, **kwargs):
-        # Parameters related to loading from Hugging Face Hub
-        cache_dir = kwargs.pop("cache_dir", None)
-        force_download = kwargs.pop("force_download", False)
-        resume_download = kwargs.pop("resume_download", False)
-        proxies = kwargs.pop("proxies", None)
-        local_files_only = kwargs.pop("local_files_only", False)
-        use_auth_token = kwargs.pop("use_auth_token", None)
-        revision = kwargs.pop("revision", None)
-        subfolder = kwargs.pop("subfolder", None)
-        commit_hash = kwargs.pop("_commit_hash", None)
-
-        transformers_config = False
-        for quantize_config_filename in [
-            "quantize_config.json",
-            "quant_config.json",
-            "config.json",
-        ]:
-            if os.path.isdir(save_dir):  # Local
-                resolved_config_file = join(save_dir, quantize_config_filename)
-            else:  # Remote
-                resolved_config_file = cached_file(
-                    save_dir,
-                    quantize_config_filename,
-                    cache_dir=cache_dir,
-                    force_download=force_download,
-                    resume_download=resume_download,
-                    proxies=proxies,
-                    use_auth_token=use_auth_token,
-                    revision=revision,
-                    local_files_only=local_files_only,
-                    subfolder=subfolder,
-                    _raise_exceptions_for_missing_entries=False,
-                    _raise_exceptions_for_connection_errors=False,
-                    _commit_hash=commit_hash,
-                )
-            if resolved_config_file is not None:
-                if quantize_config_filename == "config.json":
-                    transformers_config = True
-                break
-
-        if resolved_config_file is None:
-            raise ValueError(
-                "No quantize_config.json, quant_config.json or config.json file was found in the model repository."
-            )
-
-        field_names = [field.name for field in fields(cls)]
-        with open(resolved_config_file, "r", encoding="utf-8") as f:
-            args_from_json = json.load(f)
-
-            if transformers_config:
-                args_from_json = args_from_json["quantization_config"]
-
-            filtered_args = {"awq_gemm_checkpoint": False}
-            for key, val in args_from_json.items():
-                if key == "version" and val == "GEMM":
-                    filtered_args["awq_gemm_checkpoint"] = True
-                elif key in field_names:
-                    filtered_args[key] = val
-                elif key in SYNONYMS and SYNONYMS[key] in field_names:
-                    filtered_args[SYNONYMS[key]] = val
-                else:
-                    logger.warning(f"ignoring unknown parameter in {quantize_config_filename}: {key}.")
-
-            if filtered_args["awq_gemm_checkpoint"]:
-                # AWQ does not reorder the rows.
-                filtered_args["desc_act"] = False
-
-            if "sym" not in args_from_json:
-                logger.warning(
-                    f"The quantization configuration {quantize_config_filename} does not contain an entry `sym` (symetric quantization). This may result in silent errors."
-                )
-
-            return cls(**filtered_args)
-
-    def to_dict(self):
-        return {
-            "bits": self.bits,
-            "group_size": self.group_size,
-            "damp_percent": self.damp_percent,
-            "desc_act": self.desc_act,
-            "static_groups": self.static_groups,
-            "sym": self.sym,
-            "true_sequential": self.true_sequential,
-            "model_name_or_path": self.model_name_or_path,
-            "model_file_base_name": self.model_file_base_name,
-            "is_marlin_format": self.is_marlin_format,
-            "quant_method": "gptq",
-        }
-
 
 def nested_move_to_device(v, device):
     if isinstance(v, torch.Tensor):
@@ -206,6 +83,7 @@ def nested_move_to_device(v, device):
         return type(v)([nested_move_to_device(e, device) for e in v])
     else:
         return v
+
 
 class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
     layer_type: str = None
@@ -305,6 +183,10 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
     ):
         if self.quantized:
             raise EnvironmentError("can't execute quantize because the model is quantized.")
+
+        if self.quantize_config.quant_method in QUANTIZE_BLACK_LIST:
+            raise ValueError(f"Unsupported quantization operation for quant method: {self.quantize_config.quant_method}")
+
         if use_triton and not TRITON_AVAILABLE:
             logger.warning("triton is not installed, reset use_triton to False")
             use_triton = False
@@ -502,7 +384,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             desc_act=self.quantize_config.desc_act,
             warmup_triton=autotune_warmup_after_quantized,
             force_layer_back_to_cpu=force_layer_back_to_cpu,
-            is_marlin_format=self.quantize_config.is_marlin_format,
+            use_marlin=self.quantize_config.checkpoint_format == CHECKPOINT_FORMAT.MARLIN,
         )
         if device_map:
             self.model = remove_hook_from_module(self.model, recurse=True)
@@ -678,7 +560,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             safetensors_metadata["gptq_group_size"] = str(self.quantize_config.group_size)
             safetensors_metadata["gptq_desc_act"] = str(self.quantize_config.desc_act)
             safetensors_metadata["gptq_damp_percent"] = str(self.quantize_config.damp_percent)
-            safetensors_metadata["gptq_is_marlin_format"] = str(self.quantize_config.is_marlin_format)
+            safetensors_metadata["gptq_" + CHECKPOINT_FORMAT_FIELD] = self.quantize_config.checkpoint_format
+            safetensors_metadata["gptq_" + QUANT_METHOD_FIELD] = self.quantize_config.quant_method
 
             safe_save(state_dict, join(save_dir, model_save_name), safetensors_metadata)
         else:
@@ -826,6 +709,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         disable_exllama: Optional[bool] = None,
         disable_exllamav2: bool = False,
         use_tritonv2: bool = False,
+        checkpoint_format: Optional[str] = None,
         **kwargs,
     ):
         """load quantized model from local disk"""
@@ -923,20 +807,29 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             raise TypeError(f"{config.model_type} isn't supported yet.")
 
         if quantize_config is None:
-            quantize_config = BaseQuantizeConfig.from_pretrained(model_name_or_path, **cached_file_kwargs, **kwargs)
+            quantize_config = BaseQuantizeConfig.from_pretrained(model_name_or_path, checkpoint_format=checkpoint_format, **cached_file_kwargs, **kwargs)
+        else:
+            if not isinstance(quantize_config, BaseQuantizeConfig):
+                quantize_config = BaseQuantizeConfig.from_quant_config(quantize_config, checkpoint_format)
+
+        if quantize_config.checkpoint_format == CHECKPOINT_FORMAT.MARLIN:
+            # format marlin requires marlin kernel
+            use_marlin = True
+
+        marlin_compatible, marlin_optimized = _validate_marlin_device_support()
+        if use_marlin and (not MARLIN_AVAILABLE or not marlin_compatible):
+            raise TypeError("use_marlin is true but Marlin is not availble due to cuda/device support.")
+        elif use_marlin and not marlin_optimized:
+            logger.info(
+                "use_marlin is true and your gpu device is supported but not optimized for Marlin."
+            )
 
         if not use_marlin and MARLIN_AVAILABLE:
             unsupported_reason = _validate_marlin_compatibility(quantize_config)
-            if unsupported_reason is None and _validate_marlin_device_support():
+            if unsupported_reason is None and marlin_compatible:
                 logger.info(
                     "You passed a model that is compatible with the Marlin int4*fp16 GPTQ kernel but use_marlin is False. We recommend using `use_marlin=True` to use the optimized Marlin kernels for inference. Example: `model = AutoGPTQForCausalLM.from_quantized(..., use_marlin=True)`."
                 )
-
-        if hasattr(quantize_config, "is_marlin_format") and quantize_config.is_marlin_format and not use_marlin:
-            raise ValueError(
-                "You passed a GPTQ model saved in int4*fp16 GPTQ Marlin kernel format but are loading with use_marlin=False. "
-                "Please use `use_marlin=True` to load this model. Example: `model = AutoGPTQForCausalLM.from_quantized(..., use_marlin=True)`."
-            )
 
         if model_basename is None:
             if quantize_config.model_file_base_name:
@@ -958,7 +851,6 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             extensions += [".bin", ".pt"]
 
         model_name_or_path = str(model_name_or_path)
-        is_local = isdir(model_name_or_path)
 
         # Retrieve (and if necessary download) the quantized checkpoint(s).
         is_sharded, resolved_archive_file, true_model_basename = get_checkpoints(model_name_or_path=model_name_or_path, extensions=extensions, possible_model_basenames=possible_model_basenames, **cached_file_kwargs)
@@ -1082,7 +974,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 )
 
             # TODO: move this logic in an awq_utils.py file.
-            if quantize_config.awq_gemm_checkpoint:
+            if quantize_config.checkpoint_format == CHECKPOINT_FORMAT.AWQ_GEMM:
                 if is_sharded:
                     raise ValueError("The loading of sharded checkpoints with AWQ checkpoints is currently not supported. Please raise an issue in AutoGPTQ repository.")
 
@@ -1091,31 +983,10 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                         "Tried to load an AWQ kernel with use_marlin=True. This is currently not supported. Please open an issue in AutoGPTQ repository."
                     )
 
-                if is_local:
-                    is_cached = os.path.isfile(os.path.join(model_name_or_path, "autogptq_model.safetensors"))
-                else:
-                    namespace, subfolder = model_name_or_path.split("/")
-                    assets_path = huggingface_hub.cached_assets_path(
-                        library_name="autogptq",
-                        namespace=namespace,
-                        subfolder=subfolder,
-                    )
-                    weight_path = os.path.join(assets_path, "autogptq_model.safetensors")
-
-                    is_cached = os.path.isfile(weight_path)
+                model_cache_name, is_cached = quantize_config.get_cache_file_path()
 
                 if is_cached:
-                    if is_local:
-                        model_save_name = os.path.join(model_name_or_path, "autogptq_model.safetensors")
-                    else:
-                        namespace, subfolder = model_name_or_path.split("/")
-                        assets_path = huggingface_hub.cached_assets_path(
-                            library_name="autogptq",
-                            namespace=namespace,
-                            subfolder=subfolder,
-                        )
-                        model_save_name = os.path.join(assets_path, "autogptq_model.safetensors")
-
+                    model_save_name = model_cache_name
                     logger.info(f"Loading an AWQ model, detected a cached repacked weight at {model_save_name}.")
                 else:
                     logger.info(
@@ -1189,27 +1060,15 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                             new_state_dict[gptq_layer_name + ".qzeros"] = gptq_qzeros
                             new_state_dict[gptq_layer_name + ".scales"] = awq_scales
 
-                    # Cache the converted model.
-                    if is_local:
-                        model_save_name = os.path.join(model_name_or_path, "autogptq_model.safetensors")
-                        safe_save(new_state_dict, model_save_name)
-                    else:
-                        namespace, subfolder = model_name_or_path.split("/")
-                        assets_path = huggingface_hub.cached_assets_path(
-                            library_name="autogptq",
-                            namespace=namespace,
-                            subfolder=subfolder,
-                        )
-                        model_save_name = os.path.join(assets_path, "autogptq_model.safetensors")
-
-                        safe_save(new_state_dict, model_save_name)
+                        safe_save(new_state_dict, model_cache_name)
+                        model_save_name = model_cache_name
 
             if use_marlin:
                 if is_sharded:
                     raise ValueError("The loading of sharded checkpoints with Marlin is currently not supported. Please raise an issue in AutoGPTQ repository.")
                 if torch.version.hip:
                     raise ValueError("Can not use Marlin int4*fp16 kernel with AMD ROCm version of PyTorch as the kernel is not compatible. Please do not use `use_marlin=True` when using ROCm devices.")
-                if not torch.cuda.get_device_capability()[0] >= 8:
+                if not _validate_marlin_device_support():
                     raise ValueError(f'Can not use Marlin int4*fp16 kernel with a device of compute capability {torch.cuda.get_device_capability()}, the minimum compute capability is 8.0 for Marlin kernel. Please do not use `use_marlin=True`, or please upgrade your GPU ("The more you buy, the more you save." - Taiwanese proverb).')
 
                 # Validate the model can run in Marlin.
@@ -1230,7 +1089,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                     bits=quantize_config.bits,
                     disable_exllama=disable_exllama,
                     disable_exllamav2=disable_exllamav2,
-                    disable_marlin=True,
+                    use_marlin=False,
                     use_tritonv2=use_tritonv2,  # Get the "original" QuantLienar class
                 )
 
@@ -1239,7 +1098,6 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 #   If stub has cached marlin version   --> load from the cached versin
                 #   Otherwise                           --> convert to marlin, cache, load from cache
                 model, model_save_name = prepare_model_for_marlin_load(
-                    model_name_or_path=model_name_or_path,
                     model=model,
                     quantize_config=quantize_config,
                     quant_linear_class=quant_linear_class,
@@ -1302,6 +1160,7 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                 trainable=trainable,
                 use_qigen=True,
                 use_tritonv2=use_tritonv2,
+                use_marlin=quantize_config.checkpoint_format == CHECKPOINT_FORMAT.MARLIN,
             )
             preprocess_checkpoint_qigen(
                 model,
@@ -1428,7 +1287,9 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
     ):
         GeneralQuantLinear.inject_to_model(
             model,
-            dynamically_import_QuantLinear(use_triton, desc_act, group_size, bits=bits, disable_exllama=disable_exllama, disable_exllamav2=disable_exllamav2, disable_marlin=not use_marlin, use_qigen=use_qigen),
+            dynamically_import_QuantLinear(use_triton, desc_act, group_size, bits=bits, disable_exllama=disable_exllama,
+                                           disable_exllamav2=disable_exllamav2,
+                                           use_marlin=use_marlin, use_qigen=use_qigen),
         )
 
     def __getattr__(self, item):

--- a/auto_gptq/modeling/_utils.py
+++ b/auto_gptq/modeling/_utils.py
@@ -263,7 +263,8 @@ def pack_model(
     desc_act=False,
     warmup_triton: bool = False,
     force_layer_back_to_cpu: bool = False,
-    is_marlin_format: bool = False,
+    use_marlin: bool = False,
+    use_tritonv2: bool = False,
 ):
     QuantLinear = dynamically_import_QuantLinear(
         use_triton=use_triton,
@@ -272,7 +273,8 @@ def pack_model(
         bits=bits,
         disable_exllama=False,
         disable_exllamav2=True,
-        disable_marlin=not is_marlin_format,
+        use_marlin=use_marlin,
+        use_tritonv2=use_tritonv2,
     )
 
     if force_layer_back_to_cpu:
@@ -291,7 +293,7 @@ def pack_model(
         desc_act=desc_act,
         disable_exllama=False,
         disable_exllamav2=True,
-        use_marlin=is_marlin_format,
+        use_marlin=use_marlin,
     )
     qlayers = find_layers(model, [QuantLinear])
 

--- a/auto_gptq/modeling/_utils.py
+++ b/auto_gptq/modeling/_utils.py
@@ -93,7 +93,7 @@ def make_quant(
         desc_act=desc_act,
         group_size=group_size,
         bits=bits,
-        disable_marlin=not use_marlin,
+        use_marlin=use_marlin,
         disable_exllama=disable_exllama,
         disable_exllamav2=disable_exllamav2,
         use_qigen=use_qigen,
@@ -263,7 +263,7 @@ def pack_model(
     desc_act=False,
     warmup_triton: bool = False,
     force_layer_back_to_cpu: bool = False,
-    is_marlin_format: bool = False,
+    use_marlin: bool = False,
 ):
     QuantLinear = dynamically_import_QuantLinear(
         use_triton=use_triton,
@@ -272,7 +272,7 @@ def pack_model(
         bits=bits,
         disable_exllama=False,
         disable_exllamav2=True,
-        disable_marlin=not is_marlin_format,
+        use_marlin=use_marlin,
     )
 
     if force_layer_back_to_cpu:
@@ -291,7 +291,7 @@ def pack_model(
         desc_act=desc_act,
         disable_exllama=False,
         disable_exllamav2=True,
-        use_marlin=is_marlin_format,
+        use_marlin=use_marlin,
     )
     qlayers = find_layers(model, [QuantLinear])
 
@@ -504,9 +504,12 @@ def autogptq_post_init(model, use_act_order: bool, max_input_length: Optional[in
 
 
 def make_sure_no_tensor_in_meta_device(
-    model, use_triton: bool, desc_act: bool, group_size: int, bits: int, disable_exllama: bool, disable_exllamav2: bool, use_marlin: bool = False,
+        model, use_triton: bool, desc_act: bool, group_size: int, bits: int, disable_exllama: bool,
+        disable_exllamav2: bool, use_marlin: bool = False,
 ):
-    QuantLinear = dynamically_import_QuantLinear(use_triton, desc_act, group_size, bits=bits, disable_exllama=disable_exllama, disable_exllamav2=disable_exllamav2, disable_marlin=not use_marlin)
+    QuantLinear = dynamically_import_QuantLinear(use_triton, desc_act, group_size, bits=bits,
+                                                 disable_exllama=disable_exllama, disable_exllamav2=disable_exllamav2,
+                                                 use_marlin=use_marlin)
     for n, m in model.named_modules():
         if isinstance(m, QuantLinear) and m.bias.device == torch.device("meta"):
             m.register_buffer("bias", torch.zeros((m.outfeatures), dtype=torch.float16, device="cpu"))

--- a/auto_gptq/quantization/__init__.py
+++ b/auto_gptq/quantization/__init__.py
@@ -1,2 +1,11 @@
+from .config import (
+    CHECKPOINT_FORMAT,
+    CHECKPOINT_FORMAT_FIELD,
+    CHECKPOINT_FORMAT_FIELD_COMPAT_MARLIN,
+    QUANT_CONFIG_FILENAME,
+    QUANT_METHOD,
+    QUANT_METHOD_FIELD,
+    BaseQuantizeConfig,
+)
 from .gptq import GPTQ
 from .quantizer import Quantizer, quantize

--- a/auto_gptq/quantization/config.py
+++ b/auto_gptq/quantization/config.py
@@ -1,0 +1,248 @@
+import json
+import logging
+import os
+from dataclasses import dataclass, field, fields
+from os.path import isdir, join
+from typing import Optional
+
+import huggingface_hub
+from transformers.utils.hub import PushToHubMixin, cached_file
+
+
+logger = logging.getLogger(__name__)
+
+CHECKPOINT_FORMAT_FIELD = "checkpoint_format"
+CHECKPOINT_FORMAT_FIELD_COMPAT_MARLIN = "is_marlin_format"
+QUANT_METHOD_FIELD = "quant_method"
+QUANT_CONFIG_FILENAME = "quantize_config.json"
+
+
+# checkpoint formats
+class CHECKPOINT_FORMAT:
+    GPTQ = "gptq"
+    MARLIN = "marlin"
+    AWQ_GEMM = "gemm"
+
+
+# quant methods
+class QUANT_METHOD:
+    GPTQ = "gptq"
+    AWQ = "awq"
+
+
+QUANT_METHOD_FORMAT_MAPPING = {
+    QUANT_METHOD.GPTQ: {
+        CHECKPOINT_FORMAT.GPTQ,
+        CHECKPOINT_FORMAT.MARLIN,
+    },
+    QUANT_METHOD.AWQ: {
+        CHECKPOINT_FORMAT.AWQ_GEMM
+    }
+}
+
+# awq is inference only
+QUANTIZE_BLACK_LIST = {QUANT_METHOD.AWQ}
+
+# compat
+QUANT_CONFIG_ARG_SYNONYMS = {
+    "w_bit": "bits",
+    "q_group_size": "group_size",
+}
+
+
+@dataclass
+class BaseQuantizeConfig(PushToHubMixin):
+    bits: int = field(default=4, metadata={"choices": [2, 3, 4, 8]})
+    group_size: int = field(default=-1)
+    damp_percent: float = field(default=0.01)
+    desc_act: bool = field(default=True)
+    static_groups: bool = field(default=False)
+    sym: bool = field(default=True)
+    true_sequential: bool = field(default=True)
+    quant_method: str = field(default=QUANT_METHOD.GPTQ)
+    checkpoint_format: str = field(default=CHECKPOINT_FORMAT.GPTQ)
+    model_name_or_path: Optional[str] = field(default=None)
+    model_file_base_name: Optional[str] = field(default=None)
+
+    def __post_init__(self):
+        fields_info = fields(self)
+
+        # validate quant method and format is matched
+        valid_checkpoint_formats = QUANT_METHOD_FORMAT_MAPPING.get(self.quant_method, None)
+        if valid_checkpoint_formats is None:
+            raise ValueError(f"Unsupported quantization method: {self.quant_method}")
+
+        if self.checkpoint_format not in valid_checkpoint_formats:
+            raise ValueError(
+                f"The checkpoint format used is {self.checkpoint_format}, and the quantization method is {self.quant_method}. "
+                f"This is not supported, please open an issue at https://github.com/AutoGPTQ/AutoGPTQ/issues.")
+
+        if self.bits not in fields_info[0].metadata["choices"]:
+            raise ValueError(f"only support quantize to {fields_info[0].metadata['choices']} bits.")
+
+        if self.group_size != -1 and self.group_size <= 0:
+            raise ValueError("unless equal to -1, group_size must greater then 0.")
+
+        if not (0 < self.damp_percent < 1):
+            raise ValueError("damp_percent must between 0 and 1.")
+
+    def save_pretrained(self, save_dir: str, **kwargs):
+        with open(join(save_dir,  QUANT_CONFIG_FILENAME), "w", encoding="utf-8") as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+    @classmethod
+    # normalize quant config for compat and also performs validation
+    def from_quant_config(cls, quantize_cfg, checkpoint_format: str = None):
+        valid_formats = {CHECKPOINT_FORMAT.GPTQ, CHECKPOINT_FORMAT.MARLIN, CHECKPOINT_FORMAT.AWQ_GEMM}
+
+        # compat: checkpoint_format can be passed in via from_quantized() if field missing from json
+        if checkpoint_format:
+            if checkpoint_format not in valid_formats:
+                raise ValueError(f"Unknown quantization checkpoint format: {checkpoint_format}.")
+            if quantize_cfg.get(CHECKPOINT_FORMAT_FIELD):
+                raise ValueError("Conflict: quantization checkpoint_format is passed in and also exists in model config.")
+        # compat: warn if checkpoint_format is missing
+        elif quantize_cfg.get(CHECKPOINT_FORMAT_FIELD) is None:
+            logger.warning("checkpoint_format missing from quantization configuration and is inferred.")
+
+        field_names = [field.name for field in fields(cls)]
+
+        normalized = {QUANT_METHOD_FIELD: QUANT_METHOD.GPTQ, CHECKPOINT_FORMAT_FIELD: checkpoint_format if checkpoint_format else CHECKPOINT_FORMAT.GPTQ}
+        for key, val in quantize_cfg.items():
+            key = key.lower()
+
+            # remap keys according to compat map
+            if key in QUANT_CONFIG_ARG_SYNONYMS and QUANT_CONFIG_ARG_SYNONYMS[key] in field_names:
+                key = QUANT_CONFIG_ARG_SYNONYMS[key]
+
+            if key == CHECKPOINT_FORMAT_FIELD:
+                val = val.lower()
+
+                if val in {CHECKPOINT_FORMAT.GPTQ, CHECKPOINT_FORMAT.MARLIN, CHECKPOINT_FORMAT.AWQ_GEMM}:
+                    normalized[key] = val
+                else:
+                    raise ValueError(f"Unknown quantization format: {val}.")
+            elif key == QUANT_METHOD_FIELD:
+                val = val.lower()
+                # compat: some hf models use quant_method=marlin
+                if val == CHECKPOINT_FORMAT.MARLIN:
+                    normalized[CHECKPOINT_FORMAT_FIELD] = CHECKPOINT_FORMAT.MARLIN
+                elif val not in {QUANT_METHOD.GPTQ, QUANT_METHOD.AWQ}:
+                    raise ValueError(f"Unknown quantization method: {val}.")
+                else:
+                    normalized[QUANT_METHOD_FIELD] = val
+            elif key == CHECKPOINT_FORMAT_FIELD_COMPAT_MARLIN and val:
+                normalized[CHECKPOINT_FORMAT_FIELD] = CHECKPOINT_FORMAT.MARLIN
+            elif key == "version" and val.lower() == CHECKPOINT_FORMAT.AWQ_GEMM:
+                normalized[QUANT_METHOD_FIELD] = QUANT_METHOD.AWQ
+                normalized[CHECKPOINT_FORMAT_FIELD] = CHECKPOINT_FORMAT.AWQ_GEMM
+            elif key in field_names:
+                normalized[key] = val
+            else:
+                logger.warning(f"Ignoring unknown parameter in D configuration: {key}.")
+
+        if normalized[CHECKPOINT_FORMAT_FIELD] in {CHECKPOINT_FORMAT.AWQ_GEMM, CHECKPOINT_FORMAT.MARLIN}:
+            # AWQ and Marlin do not reorder the rows.
+            normalized["desc_act"] = False
+
+        if "sym" not in normalized:
+            logger.warning(
+                "The quantization configuration does not contain an entry `sym` (symmetric quantization). "
+                "This may result in silent errors. Defaulting to `sym=True`."
+            )
+
+        return cls(**normalized)
+
+    @classmethod
+    def from_pretrained(cls, save_dir: str, **kwargs):
+        # Parameters related to loading from Hugging Face Hub
+        cache_dir = kwargs.pop("cache_dir", None)
+        force_download = kwargs.pop("force_download", False)
+        resume_download = kwargs.pop("resume_download", False)
+        proxies = kwargs.pop("proxies", None)
+        local_files_only = kwargs.pop("local_files_only", False)
+        use_auth_token = kwargs.pop("use_auth_token", None)
+        revision = kwargs.pop("revision", None)
+        subfolder = kwargs.pop("subfolder", None)
+        commit_hash = kwargs.pop("_commit_hash", None)
+        checkpoint_format = kwargs.pop("checkpoint_format", None)
+
+        transformers_config = False
+        for quantize_config_filename in [
+            QUANT_CONFIG_FILENAME,
+            "quant_config.json",
+            "config.json",
+        ]:
+            if isdir(save_dir):  # Local
+                resolved_config_file = join(save_dir, quantize_config_filename)
+            else:  # Remote
+                resolved_config_file = cached_file(
+                    save_dir,
+                    quantize_config_filename,
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    resume_download=resume_download,
+                    proxies=proxies,
+                    use_auth_token=use_auth_token,
+                    revision=revision,
+                    local_files_only=local_files_only,
+                    subfolder=subfolder,
+                    _raise_exceptions_for_missing_entries=False,
+                    _raise_exceptions_for_connection_errors=False,
+                    _commit_hash=commit_hash,
+                )
+            if resolved_config_file is not None:
+                if quantize_config_filename == "config.json":
+                    transformers_config = True
+                break
+
+        if resolved_config_file is None:
+            raise ValueError(
+                "No quantize_config.json, quant_config.json or config.json file was found in the model repository."
+            )
+
+        with open(resolved_config_file, "r", encoding="utf-8") as f:
+            args_from_json = json.load(f)
+
+            if transformers_config:
+                args_from_json = args_from_json["quantization_config"]
+
+            return cls.from_quant_config(args_from_json, checkpoint_format)
+
+    def get_cache_file_path(self, quant_method: QUANT_METHOD = None, checkpoint_format: CHECKPOINT_FORMAT = None):
+        """
+        Gets The Cached Weight Path.
+        If remote:   $HF_HOME/assets/autogptq/{model_name_or_path}/_{quant-method}_{checkpoint_format}.safetensors
+        If local:    {model_name_or_path}/autogptq_model_{quant-method}_{checkpoint_format}.safetensors
+        """
+
+        use_quant_method = quant_method if quant_method else self.quant_method
+        use_checkpoint_format = checkpoint_format if checkpoint_format else self.checkpoint_format
+
+        cache_file_name = f"autogptq_model_{use_quant_method}_{use_checkpoint_format}.safetensors"
+
+        if os.path.isdir(self.model_name_or_path):
+            cache_file_name = os.path.join(self.model_name_or_path, cache_file_name)
+        else:
+            namespace, subfolder = self.model_name_or_path.split("/")
+            assets_path = huggingface_hub.cached_assets_path(
+                library_name="auto_gptq", namespace=namespace, subfolder=subfolder
+            )
+            cache_file_name = os.path.join(assets_path, cache_file_name)
+
+        return cache_file_name, os.path.isfile(cache_file_name)
+
+    def to_dict(self):
+        return {
+            "bits": self.bits,
+            "group_size": self.group_size,
+            "damp_percent": self.damp_percent,
+            "desc_act": self.desc_act,
+            "static_groups": self.static_groups,
+            "sym": self.sym,
+            "true_sequential": self.true_sequential,
+            "model_name_or_path": self.model_name_or_path,
+            "model_file_base_name": self.model_file_base_name,
+            QUANT_METHOD_FIELD: self.quant_method,
+            CHECKPOINT_FORMAT_FIELD: self.checkpoint_format,
+        }

--- a/auto_gptq/utils/accelerate_utils.py
+++ b/auto_gptq/utils/accelerate_utils.py
@@ -232,7 +232,7 @@ def load_checkpoint_in_model(
         del loaded_checkpoint
         gc.collect()
 
-    if not strict:
+    if not strict and len(unexpected_keys) > 0:
         logger.warning(
             f"Some weights of the model checkpoint at {checkpoint} were not used when"
             f" initializing {model.__class__.__name__}: {unexpected_keys}. This may or may not be an issue - make sure that the checkpoint does not have unnecessary parameters, or that the model definition correctly corresponds to the checkpoint."

--- a/auto_gptq/utils/import_utils.py
+++ b/auto_gptq/utils/import_utils.py
@@ -64,7 +64,7 @@ def dynamically_import_QuantLinear(
     disable_exllama: Optional[bool] = None,
     disable_exllamav2: bool = False,
     use_qigen: bool = False,
-    disable_marlin: bool = True,
+    use_marlin: bool = False,
     use_tritonv2: bool = False,
 ):
     if use_qigen:
@@ -91,7 +91,7 @@ def dynamically_import_QuantLinear(
                     disable_exllama = False
                 else:
                     disable_exllama = True
-            if bits == 4 and not disable_marlin:
+            if bits == 4 and use_marlin:
                 from ..nn_modules.qlinear.qlinear_marlin import QuantLinear
             elif bits == 4 and not disable_exllamav2 and EXLLAMAV2_KERNELS_AVAILABLE:
                 from ..nn_modules.qlinear.qlinear_exllamav2 import QuantLinear

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -1,10 +1,13 @@
+import os
 import tempfile
 import unittest
 
+import torch.cuda
 from parameterized import parameterized
 from transformers import AutoTokenizer
 
-from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
+from auto_gptq import AutoGPTQForCausalLM
+from auto_gptq.quantization import CHECKPOINT_FORMAT, QUANT_CONFIG_FILENAME, BaseQuantizeConfig
 
 
 class TestQuantization(unittest.TestCase):
@@ -21,11 +24,12 @@ class TestQuantization(unittest.TestCase):
                 "Today I am in Paris and it is a wonderful day."
             ),
         ]
+
         quantize_config = BaseQuantizeConfig(
             bits=4,
             group_size=128,
             desc_act=False,
-            is_marlin_format=use_marlin,
+            checkpoint_format=CHECKPOINT_FORMAT.MARLIN if use_marlin else CHECKPOINT_FORMAT.GPTQ,
         )
 
         model = AutoGPTQForCausalLM.from_pretrained(
@@ -40,3 +44,31 @@ class TestQuantization(unittest.TestCase):
             model.save_pretrained(tmpdirname)
 
             model = AutoGPTQForCausalLM.from_quantized(tmpdirname, device="cuda:0", use_marlin=use_marlin)
+            del model
+            torch.cuda.empty_cache()
+
+            # test compat: 1) with simple dict type 2) is_marlin_format
+            compat_quantize_config = {
+                "bits": 4,
+                "group_size": 128,
+                "desc_act": False,
+                "is_marlin_format": use_marlin,
+            }
+            model = AutoGPTQForCausalLM.from_quantized(tmpdirname, device="cuda:0", quantize_config=compat_quantize_config)
+            assert(isinstance(model.quantize_config, BaseQuantizeConfig))
+
+            del model
+            torch.cuda.empty_cache()
+
+            # test checkinpoint_format hint to from_quantized()
+            os.remove(f"{tmpdirname}/{QUANT_CONFIG_FILENAME}")
+
+            compat_quantize_config = {
+                "bits": 4,
+                "group_size": 128,
+                "desc_act": False,
+            }
+            model = AutoGPTQForCausalLM.from_quantized(tmpdirname, device="cuda:0",
+                    quantize_config=compat_quantize_config,
+                    checkpoint_format=CHECKPOINT_FORMAT.MARLIN if use_marlin else None)
+            assert (isinstance(model.quantize_config, BaseQuantizeConfig))

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -4,47 +4,46 @@ import tempfile
 import time
 import unittest
 
-import huggingface_hub
-
 from auto_gptq import AutoGPTQForCausalLM
-from auto_gptq.utils.marlin_utils import _get_cached_marlin_save_name
+from auto_gptq.quantization import CHECKPOINT_FORMAT, CHECKPOINT_FORMAT_FIELD, QUANT_CONFIG_FILENAME
+from auto_gptq.quantization.config import QUANT_METHOD, BaseQuantizeConfig
 
 
 class TestSerialization(unittest.TestCase):
     MODEL_ID = "habanoz/TinyLlama-1.1B-Chat-v0.3-GPTQ"
 
     def setUp(self):
-        namespace, subfolder = self.MODEL_ID.split("/")
-        assets_path = huggingface_hub.cached_assets_path(
-            library_name="auto_gptq", namespace=namespace, subfolder=subfolder
-        )
-        cached_model_path = os.path.join(assets_path, "autogptq_model.safetensors")
+        dummy_config = BaseQuantizeConfig(
+            model_name_or_path=self.MODEL_ID,
+            quant_method=QUANT_METHOD.GPTQ,
+            checkpoint_format=CHECKPOINT_FORMAT.MARLIN)
 
-        if os.path.isfile(cached_model_path):
-            os.remove(cached_model_path)
+        model_cache_path, is_cached = dummy_config.get_cache_file_path()
+
+        if is_cached:
+            os.remove(model_cache_path)
 
     def test_marlin_local_serialization(self):
         start = time.time()
         model = AutoGPTQForCausalLM.from_quantized(self.MODEL_ID, device="cuda:0", use_marlin=True)
         end = time.time()
-
         first_load_time = end - start
 
         with tempfile.TemporaryDirectory() as tmpdir:
             model.save_pretrained(tmpdir)
 
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "model.safetensors")))
-            self.assertFalse(os.path.isfile(os.path.join(tmpdir, "autogptq_model.safetensors")))
+            model_cache_path, is_cached = model.quantize_config.get_cache_file_path()
+            self.assertFalse(os.path.isfile(os.path.join(tmpdir, model_cache_path)))
 
-            with open(os.path.join(tmpdir, "quantize_config.json"), "r") as config_file:
+            with open(os.path.join(tmpdir, QUANT_CONFIG_FILENAME), "r") as config_file:
                 config = json.load(config_file)
 
-            self.assertTrue(config["is_marlin_format"])
+            self.assertTrue(config[CHECKPOINT_FORMAT_FIELD] == CHECKPOINT_FORMAT.MARLIN)
 
             start = time.time()
             model = AutoGPTQForCausalLM.from_quantized(tmpdir, device="cuda:0", use_marlin=True)
             end = time.time()
-
             second_load_time = end - start
 
         # Since we use a CUDA kernel to repack weights, the first load time is already small.
@@ -52,19 +51,19 @@ class TestSerialization(unittest.TestCase):
 
     def test_marlin_hf_cache_serialization(self):
         start = time.time()
-        _ = AutoGPTQForCausalLM.from_quantized(self.MODEL_ID, device="cuda:0", use_marlin=True)
+        model = AutoGPTQForCausalLM.from_quantized(self.MODEL_ID, device="cuda:0", use_marlin=True)
+        self.assertTrue(model.quantize_config.checkpoint_format == CHECKPOINT_FORMAT.MARLIN)
         end = time.time()
-
         first_load_time = end - start
 
-        model_cache_path = _get_cached_marlin_save_name(self.MODEL_ID)
+        model_cache_path, is_cached = model.quantize_config.get_cache_file_path()
         self.assertTrue("assets" in model_cache_path)
-        self.assertTrue(os.path.isfile(model_cache_path))
+        self.assertTrue(is_cached)
 
         start = time.time()
-        _ = AutoGPTQForCausalLM.from_quantized(self.MODEL_ID, device="cuda:0", use_marlin=True)
+        model = AutoGPTQForCausalLM.from_quantized(self.MODEL_ID, device="cuda:0", use_marlin=True)
+        self.assertTrue(model.quantize_config.checkpoint_format == CHECKPOINT_FORMAT.MARLIN)
         end = time.time()
-
         second_load_time = end - start
 
         # Since we use a CUDA kernel to repack weights, the first load time is already small.


### PR DESCRIPTION
Core reason for PR:

Unify the concept of model weight `format` since repo already have coding for 3 weight formats: gptq, marlin, and awq_gemm with 4th pending in #559. Without this PR, existing properties of different weight formats are fragmented and not forward compatible with new formats such as pending #559 which will require another property field. Have one single `format` field to unify them all.

Changes:

* MAJOR `format` unifies `is_marlin_format`,  `awq_qemm`, and pending `gptq_v2` format in pr #559
* `format` defaults to `gptq`
* MAJOR `gptq_method` remapped to `method` 
* MAJOR compat: pinned transformers to < 4.39.0 due to #604
* fix _validate_marlin_device_support() returns false for ada/hopper. Fix #616 
* fix  json arg normalization comparisons did not use lowercased keys and string values
* block awq gemm from participating in quantization: inference only
* added compat for some hf models using `quant_method=marlin` for marlin models using other gptq quantizers
* load quant `method` into  BaseQuantizeConfig. Previously this was ignored, not read from json.
* auto set `use_marlin` to True when model weight format is marlin.
* renamed marlin cache file from  `autogptq_model.safetensors` to more explicit  `autogptq_model_marlin.safetensors`


Reason for the naming changes. `format` means checkpoint format and `method` means quant method but as both properties are specific to `BaseQuantizeConfig`, there is no need to append quant to method and similarly `format` is clear and non-conflicting. 

Backward Compatibility

* autogptq loading pre-pr quantized models marlin/non-marlin have been tested 
* third party using new quantized models will need compat update: i.e. vllm/sglang. 

This is breaking change for downstream users of models quantized by autogptq that do not use the autogptq inference engine.  To mitigate impact, I will parallel pr compat changes to vllm/sglang repos once this is ready to merge.  

TEST Results:

[PASS] Pre-PR: Both marlin and non-marlin load 
[PASS] PR: Both marlin and non-marlin load 

[PASS] test_quantizataion.py 
[PASS] test_serialization.py 
[PASS] test_q4.py
[PASS] test_shared_loading.py
[PASS] test_awq_compatibility_generation.py

Failed tests but these tests also failed on main:
[FAIL] test_triton.py
[FAIL] test_peft.py
[FAIL] test_repacking.py 
 