### PR TITLE
Pin transformers to <4.39.0  Fix Issue #604

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ requirements = [
     "gekko",
     "torch>=1.13.0",
     "safetensors",
-    "transformers>=4.31.0",
+    "transformers>=4.31.0,<4.39.0",
     "peft>=0.5.0",
     "tqdm",
 ]


### PR DESCRIPTION
Latest transformers broke llama model quantization and likely other as well. 

Temporarily pin transformers to <4.39.0 until compatibility is fully fixed.

Fix/Bypass Issue #604 

@fxmarty @PanQiWei  Ready for review.