### PR TITLE
Add support for InternLM-XComposer2-VL

### DIFF
--- a/auto_gptq/modeling/internlm.py
+++ b/auto_gptq/modeling/internlm.py
@@ -4,12 +4,16 @@ from ._base import BaseGPTQForCausalLM
 class InternLMGPTQForCausalLM(BaseGPTQForCausalLM):
     layer_type = "InternLMDecoderLayer"
     layers_block_name = "model.layers"
-    outside_layer_modules = ["model.embed_tokens", "model.norm"]
+    outside_layer_modules = ["model.embed_tokens", "model.norm", "vit", "vision_proj", "model.tok_embeddings", "output"]
     inside_layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
         ["self_attn.o_proj"],
         ["mlp.up_proj", "mlp.gate_proj"],
         ["mlp.down_proj"],
+        ["attention.wqkv.linear"],  # InternLMXComposer2
+        ["attention.wo.linear"],
+        ["feed_forward.w1.linear", "feed_forward.w3.linear"],
+        ["feed_forward.w2.linear"],
     ]
 
 


### PR DESCRIPTION
This adds support for [InternLM-XComposer2-VL](https://github.com/InternLM/InternLM-XComposer/tree/main#4-bit-model)
Based on the code from their repo.

Since they use the same `internlm` modeltype but completely different layout, this is implemented in a slightly hacky way into the same class, letting AutoGPTQ to ignore missing modules so both can be supported.

Closes #590 