### PR TITLE
Hopper is not validated for Marlin

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -816,12 +816,12 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             # format marlin requires marlin kernel
             use_marlin = True
 
-        marlin_compatible, marlin_optimized = _validate_marlin_device_support()
+        marlin_compatible, marlin_validated = _validate_marlin_device_support()
         if use_marlin and (not MARLIN_AVAILABLE or not marlin_compatible):
             raise TypeError("use_marlin is true but Marlin is not availble due to cuda/device support.")
-        elif use_marlin and not marlin_optimized:
-            logger.info(
-                "use_marlin is true and your gpu device is supported but not optimized for Marlin."
+        elif use_marlin and not marlin_validated:
+            logger.warn(
+                "use_marlin is true but your gpu device is not validated for Marlin and may exhibit errors."
             )
 
         if not use_marlin and MARLIN_AVAILABLE:

--- a/auto_gptq/utils/marlin_utils.py
+++ b/auto_gptq/utils/marlin_utils.py
@@ -89,26 +89,27 @@ def prepare_model_for_marlin_load(
 # Validate marlin support
 def _validate_marlin_device_support() -> Tuple[bool, bool]:
     """
-        Validates if the current device is compatible and optimized for Marlin.
-        ref: https://github.com/IST-DASLab/marlin?tab=readme-ov-file#requirements
+    Validates if the current device is compatible and optimized for Marlin.
+    ref: https://github.com/IST-DASLab/marlin?tab=readme-ov-file#requirements
 
-        Returns:
-            Tuple[bool, bool]: The first indicates if CUDA device is compatible for Marlin,
-                               the second indicates if CUDA device is optimized for Marlin.
-        """
+    Returns:
+        Tuple[bool, bool]: The first indicates if CUDA device is compatible for Marlin,
+                           the second indicates if CUDA device is validated for Marlin.
+    """
     supported = False
-    optimized = False
+    validated = False
 
-    # >=hopper is compatible but not optimized
+    # >=hopper has partial support
+    # ref https://github.com/IST-DASLab/marlin/issues/7
+    # ref https://github.com/IST-DASLab/marlin/issues/6
     if torch.cuda.get_device_capability()[0] >= 9:
         supported = True
-        optimized = False
-    # ampere and ada are supported and optimized
+    # ampere and ada are fully validated
     elif torch.cuda.get_device_capability()[0] >= 8:
         supported = True
-        optimized = True
+        validated = True
 
-    return supported, optimized
+    return supported, validated
 
 
 # Adapted from https://github.com/rib-2/marlin/tree/conversion


### PR DESCRIPTION
Warn users on Hopper as some shapes `[128, 128]`  may error.  There is conflicting report on Hopper. 
 
1. Hopper can run Dasl/Marlin benchmark: https://github.com/IST-DASLab/marlin/issues/7 which tested Llama7B + 65B Marlin quants
2. But crashed on `[128, 128]` internal accuracy test: https://github.com/IST-DASLab/marlin/issues/6 . 

PR changed message to warn for Hopper. 
 
 @fxmarty I was overly optimistic.  