### PR TITLE
Fix padding not used correctly in exllama v2 layer

### DIFF
--- a/auto_gptq/nn_modules/qlinear/qlinear_exllama.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_exllama.py
@@ -58,8 +58,11 @@ class QuantLinear(nn.Module):
         if trainable:
             raise NotImplementedError("Exllama kernel does not support training.")
 
+        self.padding = -outfeatures % 32
+        self.outfeatures = outfeatures + self.padding
+        outfeatures = self.outfeatures
+
         self.infeatures = infeatures
-        self.outfeatures = outfeatures
         self.bits = bits
         self.group_size = group_size if group_size != -1 else infeatures
         self.trainable = trainable

--- a/auto_gptq/nn_modules/qlinear/qlinear_exllamav2.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_exllamav2.py
@@ -121,10 +121,12 @@ class QuantLinear(nn.Module):
 
         self.q_handle = None
         self.q_tensors = None
+
         self.padding = -outfeatures % 32
+        self.outfeatures = outfeatures + self.padding
+        outfeatures = self.outfeatures
 
         self.infeatures = infeatures
-        self.outfeatures = outfeatures + self.padding
         self.bits = bits
         self.group_size = group_size if group_size != -1 else infeatures
         self.trainable = trainable


### PR DESCRIPTION
While hacking away in the dbrx code in #625 I found apparent errors in exllama code where padding was calculated but never used triggering`assert outfeaters % 32  == 0` when it should not have.

PR:

1. fixed padding code for exllama v2 `outfeatures` not correctly applied
2. ported same padding code from v2 to v1

test_q4 passed. 

I am not sure how to test this since the current test_q4 does not contain tests that have models with `outfeatures` that require padding. 

@fxmarty 

