### PR TITLE
Force warn users to reduce threads or packing may regress ~100x

### DIFF
--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -1,4 +1,14 @@
 import os
+import math
+
+max_threads = str(min(8, os.cpu_count()))
+os.environ['OMP_NUM_THREADS'] = max_threads
+os.environ['OPENBLAS_NUM_THREADS'] = max_threads
+os.environ['MKL_NUM_THREADS'] = max_threads
+os.environ['VECLIB_MAXIMUM_THREADS'] = max_threads
+os.environ['NUMEXPR_NUM_THREADS'] = max_threads
+os.environ['NUMEXPR_MAX_THREADS'] = max_threads
+
 import tempfile
 import unittest
 


### PR DESCRIPTION
This fix packing regression found in [#625 ](https://github.com/AutoGPTQ/AutoGPTQ/pull/625#issuecomment-2028647704)

The core cause is very strange and debilitating. Packing performance will slow down to a crawl on my env yet linux `load` value < cores by significant margin showing no thread oversubscription. Based on what I observe, launching more than 8 threads has zero to negative impact on `pack()`  performance. 

My estimation is that the extra threads are doing nothing but context switching (due to internal locks?) and performing very little actual work which results in the massive regression in packing. In fact, setting value to 1 is just as good but not as fast as 8. 

We can't fix this in code since the thread limit must happen before all any tensor libs are imported. I believe a forced warning with a sample code snippet should do the trick. 

Changes:

1. add logger.warn to .quantize()
2. limit threads in `tests/test_quantization`: this improved quant performance by 2.82x. 195.02s -> 69.14s.

@fxmarty  This is a non-breaking high priority fix as it can render .quantize() unusable when model is of sufficient size and regression becomes worse the more cores you have in your env. To illustrate how bad this is, you may quant faster on a laptop with 8 cores than a zen4 with 256 cores by factors of 50-100x due to `pack()`.