### PR TITLE
[SYCL] Intel SYCL runtime support for AutoGPTQ 

### DIFF
--- a/autogptq_extension/sycl/MainSourceFiles.yaml
+++ b/autogptq_extension/sycl/MainSourceFiles.yaml
@@ -1,0 +1,2620 @@
+---
+MainSourceFile:  ''
+Replacements:
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          49
+    Length:          18
+    ReplacementText: "#include <sycl/sycl.hpp>\n#include <dpct/dpct.hpp>\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          67
+    Length:          26
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          93
+    Length:          23
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          954
+    Length:          13
+    ReplacementText: DPCT_COMPATIBILITY_TEMP
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          972
+    Length:          13
+    ReplacementText: DPCT_COMPATIBILITY_TEMP
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          2523
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          2879
+    Length:          0
+    ReplacementText: ",\n\tconst sycl::nd_item<3> &item_ct1,\n\tscalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          2912
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          3268
+    Length:          0
+    ReplacementText: ",\n\tconst sycl::nd_item<3> &item_ct1,\n\tscalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          3301
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          3657
+    Length:          0
+    ReplacementText: ",\n\tconst sycl::nd_item<3> &item_ct1,\n\tscalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          3690
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          4046
+    Length:          0
+    ReplacementText: ",\n\tconst sycl::nd_item<3> &item_ct1,\n\tscalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          4079
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          4423
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    scalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          4456
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          4799
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    scalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          4832
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          5175
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    scalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          5208
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          5551
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    scalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          5555
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          5615
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          5893
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    sycl::half2 *blockvec,\n    sycl::local_accessor<sycl::half2, 2> deq2"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          5897
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          5957
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          6235
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    sycl::half2 *blockvec,\n    sycl::local_accessor<sycl::half2, 2> deq2"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          6239
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          6299
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          6577
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    sycl::half2 *blockvec,\n    sycl::local_accessor<sycl::half2, 2> deq2"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          6732
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          6834
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          7228
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          7240
+    Length:          93
+    ReplacementText: '1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          7338
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          7351
+    Length:          10
+    ReplacementText: 1, 1, BLOCKWIDTH
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          7738
+    Length:          11
+    ReplacementText: "/*\nDPCT1110:0: The total declared local variable size in device function VecQuant2MatMulKernel exceeds 128 bytes and may cause high register pressure. Consult with your hardware vendor to find the total register size available and adjust the code, or use smaller sub-group size to avoid high register pressure.\n*/\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          8094
+    Length:          0
+    ReplacementText: ",\n\tconst sycl::nd_item<3> &item_ct1,\n\tscalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          8123
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          8158
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(1)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          8171
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          8187
+    Length:          41
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          8886
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          8922
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          8948
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          8962
+    Length:          0
+    ReplacementText: "    /*\n    DPCT1118:1: SYCL group functions and algorithms must be encountered in converged control flow. You may need to adjust the code.\n    */\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          8966
+    Length:          15
+    ReplacementText: "/*\n    DPCT1065:12: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n    */\n    item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          9101
+    Length:          0
+    ReplacementText: "    /*\n    DPCT1118:2: SYCL group functions and algorithms must be encountered in converged control flow. You may need to adjust the code.\n    */\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          9105
+    Length:          15
+    ReplacementText: "/*\n    DPCT1065:13: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n    */\n    item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          9443
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          9455
+    Length:          93
+    ReplacementText: '1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT3 - 1) / BLOCKHEIGHT3'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          9553
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          9566
+    Length:          10
+    ReplacementText: 1, 1, BLOCKWIDTH
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          9953
+    Length:          11
+    ReplacementText: "/*\nDPCT1110:3: The total declared local variable size in device function VecQuant3MatMulKernel exceeds 128 bytes and may cause high register pressure. Consult with your hardware vendor to find the total register size available and adjust the code, or use smaller sub-group size to avoid high register pressure.\n*/\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          10312
+    Length:          0
+    ReplacementText: ",\n\tconst sycl::nd_item<3> &item_ct1,\n\tscalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          10341
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          10376
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(1)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          10389
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          10405
+    Length:          41
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          12559
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          12595
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          12621
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          12635
+    Length:          0
+    ReplacementText: "    /*\n    DPCT1118:4: SYCL group functions and algorithms must be encountered in converged control flow. You may need to adjust the code.\n    */\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          12639
+    Length:          15
+    ReplacementText: "/*\n    DPCT1065:14: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n    */\n    item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          12774
+    Length:          0
+    ReplacementText: "    /*\n    DPCT1118:5: SYCL group functions and algorithms must be encountered in converged control flow. You may need to adjust the code.\n    */\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          12778
+    Length:          15
+    ReplacementText: "/*\n    DPCT1065:15: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n    */\n    item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          13116
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          13128
+    Length:          93
+    ReplacementText: '1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT4 - 1) / BLOCKHEIGHT4'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          13226
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          13239
+    Length:          10
+    ReplacementText: 1, 1, BLOCKWIDTH
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          13626
+    Length:          11
+    ReplacementText: "/*\nDPCT1110:6: The total declared local variable size in device function VecQuant4MatMulKernel exceeds 128 bytes and may cause high register pressure. Consult with your hardware vendor to find the total register size available and adjust the code, or use smaller sub-group size to avoid high register pressure.\n*/\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          13985
+    Length:          0
+    ReplacementText: ",\n\tconst sycl::nd_item<3> &item_ct1,\n\tscalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          14014
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          14049
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(1)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          14062
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          14078
+    Length:          41
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          14738
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          14774
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          14800
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          14814
+    Length:          0
+    ReplacementText: "    /*\n    DPCT1118:7: SYCL group functions and algorithms must be encountered in converged control flow. You may need to adjust the code.\n    */\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          14818
+    Length:          15
+    ReplacementText: "/*\n    DPCT1065:16: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n    */\n    item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          14953
+    Length:          0
+    ReplacementText: "    /*\n    DPCT1118:8: SYCL group functions and algorithms must be encountered in converged control flow. You may need to adjust the code.\n    */\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          14957
+    Length:          15
+    ReplacementText: "/*\n    DPCT1065:17: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n    */\n    item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          15295
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          15307
+    Length:          93
+    ReplacementText: '1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT8 - 1) / BLOCKHEIGHT8'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          15405
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          15418
+    Length:          10
+    ReplacementText: 1, 1, BLOCKWIDTH
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          15805
+    Length:          11
+    ReplacementText: "/*\nDPCT1110:9: The total declared local variable size in device function VecQuant8MatMulKernel exceeds 128 bytes and may cause high register pressure. Consult with your hardware vendor to find the total register size available and adjust the code, or use smaller sub-group size to avoid high register pressure.\n*/\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          16164
+    Length:          0
+    ReplacementText: ",\n\tconst sycl::nd_item<3> &item_ct1,\n\tscalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          16193
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          16228
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(1)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          16241
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          16257
+    Length:          41
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          16918
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          16954
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          16980
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          16994
+    Length:          0
+    ReplacementText: "    /*\n    DPCT1118:10: SYCL group functions and algorithms must be encountered in converged control flow. You may need to adjust the code.\n    */\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          16998
+    Length:          15
+    ReplacementText: "/*\n    DPCT1065:18: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n    */\n    item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          17133
+    Length:          0
+    ReplacementText: "    /*\n    DPCT1118:11: SYCL group functions and algorithms must be encountered in converged control flow. You may need to adjust the code.\n    */\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          17137
+    Length:          15
+    ReplacementText: "/*\n    DPCT1065:19: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n    */\n    item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          17474
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          17486
+    Length:          104
+    ReplacementText: 'batch, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          17595
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          17608
+    Length:          10
+    ReplacementText: 1, 1, BLOCKWIDTH
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          17995
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          18338
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    scalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          18352
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(0)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          18389
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          18424
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(1)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          18437
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          18453
+    Length:          41
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          18506
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          18542
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          18568
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          18584
+    Length:          15
+    ReplacementText: "/*\n  DPCT1065:20: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n  */\n  item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          20590
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          20602
+    Length:          104
+    ReplacementText: 'batch, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT3 - 1) / BLOCKHEIGHT3'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          20711
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          20724
+    Length:          10
+    ReplacementText: 1, 1, BLOCKWIDTH
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          21111
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          21454
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    scalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          21468
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(0)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          21505
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          21540
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(1)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          21553
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          21569
+    Length:          41
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          21622
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          21658
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          21684
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          21700
+    Length:          15
+    ReplacementText: "/*\n  DPCT1065:21: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n  */\n  item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          26047
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          26059
+    Length:          104
+    ReplacementText: 'batch, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT4 - 1) / BLOCKHEIGHT4'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          26168
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          26181
+    Length:          10
+    ReplacementText: 1, 1, BLOCKWIDTH
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          26568
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          26915
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    scalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          26929
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(0)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          26966
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          27001
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(1)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          27014
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          27030
+    Length:          41
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          27083
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          27119
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          27145
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          27161
+    Length:          15
+    ReplacementText: "/*\n  DPCT1065:22: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n  */\n  item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          28561
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          28573
+    Length:          104
+    ReplacementText: 'batch, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT8 - 1) / BLOCKHEIGHT8'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          28682
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          28695
+    Length:          10
+    ReplacementText: 1, 1, BLOCKWIDTH
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          29082
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          29425
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    scalar_t *blockvec"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          29439
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(0)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          29476
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          29511
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(1)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          29524
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          29540
+    Length:          41
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          29593
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          29629
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          29655
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          29671
+    Length:          15
+    ReplacementText: "/*\n  DPCT1065:23: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n  */\n  item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          30771
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          30783
+    Length:          104
+    ReplacementText: 'batch, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          30892
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          30905
+    Length:          10
+    ReplacementText: 1, 1, BLOCKWIDTH
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          30921
+    Length:          255
+    ReplacementText: "{\n    dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp16});\n    dpct::get_in_order_queue().submit(\n      [&](sycl::handler &cgh) {\n        /*\n        DPCT1101:27: 'blockwidth2' expression was replaced with a value. Modify the code to use the original expression, provided in comments, if it is correct.\n        */\n        sycl::local_accessor<sycl::half2, 1> blockvec_acc_ct1(sycl::range<1>(128/*blockwidth2*/), cgh);\n        sycl::local_accessor<sycl::half2, 2> deq2_acc_ct1(sycl::range<2>(16, 16), cgh);\n\n        sycl::half2 * vec_data_ptr_ct0 = (sycl::half2*) vec.data_ptr();\n        const int *__restrict mat_data_ptr_int_ct1 = mat.data_ptr<int>();\n        float *__restrict mul_data_ptr_float_ct2 = mul.data_ptr<float>();\n        const float *__restrict scales_data_ptr_float_ct3 = scales.data_ptr<float>();\n        const int *__restrict zeros_data_ptr_int_ct4 = zeros.data_ptr<int>();\n\n        cgh.parallel_for(\n          sycl::nd_range<3>(blocks * threads, threads), \n          [=](sycl::nd_item<3> item_ct1) {\n            VecQuant2MatMulKernelFaster_old(vec_data_ptr_ct0, mat_data_ptr_int_ct1, mul_data_ptr_float_ct2, scales_data_ptr_float_ct3, zeros_data_ptr_int_ct4, batch, vec_height, height, width, zero_width, groupsize, item_ct1, blockvec_acc_ct1.get_pointer(), deq2_acc_ct1);\n          });\n      });\n  }"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: true
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31176
+    Length:          1
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31181
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31241
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31513
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    sycl::half2 *blockvec,\n    sycl::local_accessor<sycl::half2, 2> deq2"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31569
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(0)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31606
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31641
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(1)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31654
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31670
+    Length:          39
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31716
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31756
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31792
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31819
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31836
+    Length:          30
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31879
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31909
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          31993
+    Length:          78
+    ReplacementText: 'sycl::half2(sycl::vec<int, 1>(val & 0x3).convert<sycl::half, sycl::rounding_mode::rte>()[0], sycl::vec<int, 1>(val >> 2).convert<sycl::half, sycl::rounding_mode::rte>()[0])'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          32205
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          32241
+    Length:          15
+    ReplacementText: "/*\n  DPCT1065:24: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n  */\n  item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          32372
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          32386
+    Length:          25
+    ReplacementText: 'sycl::float2(scale_f).convert<sycl::half, sycl::rounding_mode::rte>()'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          32417
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          32430
+    Length:          105
+    ReplacementText: 'sycl::float2(-(scale_f * ((((as_unsigned(zeros[g * zero_width + z_w]) >> z_mod) & 0x3) + 1) & 0x0f))).convert<sycl::half, sycl::rounding_mode::rte>()'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          32622
+    Length:          82
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp >>  0) & 0xf][off], scale, zero), blockvec[k + 0], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          32717
+    Length:          82
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp >>  4) & 0xf][off], scale, zero), blockvec[k + 1], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          32812
+    Length:          82
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp >>  8) & 0xf][off], scale, zero), blockvec[k + 2], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          32907
+    Length:          82
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp >> 12) & 0xf][off], scale, zero), blockvec[k + 3], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          33002
+    Length:          82
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp >> 16) & 0xf][off], scale, zero), blockvec[k + 4], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          33097
+    Length:          82
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp >> 20) & 0xf][off], scale, zero), blockvec[k + 5], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          33192
+    Length:          82
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp >> 24) & 0xf][off], scale, zero), blockvec[k + 6], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          33287
+    Length:          82
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp >> 28) & 0xf][off], scale, zero), blockvec[k + 7], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          33407
+    Length:          17
+    ReplacementText: 'res2[0]'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          33427
+    Length:          18
+    ReplacementText: 'res2[1]'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          33454
+    Length:          35
+    ReplacementText: 'dpct::atomic_fetch_add<sycl::access::address_space::generic_space>(&mul[b * width + w], res)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          33799
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          33811
+    Length:          104
+    ReplacementText: 'batch, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT3 - 1) / BLOCKHEIGHT3'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          33920
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          33933
+    Length:          10
+    ReplacementText: 1, 1, BLOCKWIDTH
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          33949
+    Length:          255
+    ReplacementText: "{\n    dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp16});\n    dpct::get_in_order_queue().submit(\n      [&](sycl::handler &cgh) {\n        /*\n        DPCT1101:28: 'blockwidth2' expression was replaced with a value. Modify the code to use the original expression, provided in comments, if it is correct.\n        */\n        sycl::local_accessor<sycl::half2, 1> blockvec_acc_ct1(sycl::range<1>(128/*blockwidth2*/), cgh);\n        sycl::local_accessor<sycl::half2, 2> deq2_acc_ct1(sycl::range<2>(64, 32), cgh);\n\n        sycl::half2 * vec_data_ptr_ct0 = (sycl::half2*) vec.data_ptr();\n        const int *__restrict mat_data_ptr_int_ct1 = mat.data_ptr<int>();\n        float *__restrict mul_data_ptr_float_ct2 = mul.data_ptr<float>();\n        const float *__restrict scales_data_ptr_float_ct3 = scales.data_ptr<float>();\n        const int *__restrict zeros_data_ptr_int_ct4 = zeros.data_ptr<int>();\n\n        cgh.parallel_for(\n          sycl::nd_range<3>(blocks * threads, threads), \n          [=](sycl::nd_item<3> item_ct1) {\n            VecQuant3MatMulKernelFaster_old(vec_data_ptr_ct0, mat_data_ptr_int_ct1, mul_data_ptr_float_ct2, scales_data_ptr_float_ct3, zeros_data_ptr_int_ct4, batch, vec_height, height, width, zero_width, groupsize, item_ct1, blockvec_acc_ct1.get_pointer(), deq2_acc_ct1);\n          });\n      });\n  }"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: true
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34204
+    Length:          1
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34209
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34269
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34541
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    sycl::half2 *blockvec,\n    sycl::local_accessor<sycl::half2, 2> deq2"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34597
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(0)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34634
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34669
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(1)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34682
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34698
+    Length:          39
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34744
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34784
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34820
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34847
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34864
+    Length:          30
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34907
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          34937
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          35021
+    Length:          78
+    ReplacementText: 'sycl::half2(sycl::vec<int, 1>(val & 0x7).convert<sycl::half, sycl::rounding_mode::rte>()[0], sycl::vec<int, 1>(val >> 3).convert<sycl::half, sycl::rounding_mode::rte>()[0])'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          35609
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          35709
+    Length:          15
+    ReplacementText: "/*\n  DPCT1065:25: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n  */\n  item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          35840
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          35854
+    Length:          25
+    ReplacementText: 'sycl::float2(scale_f).convert<sycl::half, sycl::rounding_mode::rte>()'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          35885
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          36061
+    Length:          53
+    ReplacementText: 'sycl::float2(-(scale_f * (((z_tmp) + 1) & 0x0f))).convert<sycl::half, sycl::rounding_mode::rte>()'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          36286
+    Length:          53
+    ReplacementText: 'sycl::float2(-(scale_f * (((z_tmp) + 1) & 0x0f))).convert<sycl::half, sycl::rounding_mode::rte>()'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          36367
+    Length:          105
+    ReplacementText: 'sycl::float2(-(scale_f * ((((as_unsigned(zeros[g * zero_width + z_w]) >> z_bit) & 0x7) + 1) & 0x0f))).convert<sycl::half, sycl::rounding_mode::rte>()'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          36566
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp1 >>  0) & 0x3f][off], scale, zero), blockvec[k + 0], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          36663
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp1 >>  6) & 0x3f][off], scale, zero), blockvec[k + 1], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          36760
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp1 >> 12) & 0x3f][off], scale, zero), blockvec[k + 2], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          36857
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp1 >> 18) & 0x3f][off], scale, zero), blockvec[k + 3], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          36954
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp1 >> 24) & 0x3f][off], scale, zero), blockvec[k + 4], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          37146
+    Length:          68
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[tmp][off], scale, zero), blockvec[k + 5], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          37255
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp2 >>  0) & 0x3f][off], scale, zero), blockvec[k + 0], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          37352
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp2 >>  6) & 0x3f][off], scale, zero), blockvec[k + 1], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          37449
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp2 >> 12) & 0x3f][off], scale, zero), blockvec[k + 2], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          37546
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp2 >> 18) & 0x3f][off], scale, zero), blockvec[k + 3], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          37738
+    Length:          68
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[tmp][off], scale, zero), blockvec[k + 4], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          37847
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp1 >>  0) & 0x3f][off], scale, zero), blockvec[k + 0], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          37944
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp1 >>  6) & 0x3f][off], scale, zero), blockvec[k + 1], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          38041
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp1 >> 12) & 0x3f][off], scale, zero), blockvec[k + 2], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          38138
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp1 >> 18) & 0x3f][off], scale, zero), blockvec[k + 3], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          38235
+    Length:          84
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp1 >> 24) & 0x3f][off], scale, zero), blockvec[k + 4], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          38360
+    Length:          17
+    ReplacementText: 'res2[0]'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          38380
+    Length:          18
+    ReplacementText: 'res2[1]'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          38407
+    Length:          35
+    ReplacementText: 'dpct::atomic_fetch_add<sycl::access::address_space::generic_space>(&mul[b * width + w], res)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          38752
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          38764
+    Length:          104
+    ReplacementText: 'batch, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT4 - 1) / BLOCKHEIGHT4'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          38873
+    Length:          4
+    ReplacementText: 'sycl::range<3>'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          38886
+    Length:          10
+    ReplacementText: 1, 1, BLOCKWIDTH
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          38902
+    Length:          255
+    ReplacementText: "{\n    dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp16});\n    dpct::get_in_order_queue().submit(\n      [&](sycl::handler &cgh) {\n        /*\n        DPCT1101:29: 'blockwidth2' expression was replaced with a value. Modify the code to use the original expression, provided in comments, if it is correct.\n        */\n        sycl::local_accessor<sycl::half2, 1> blockvec_acc_ct1(sycl::range<1>(128/*blockwidth2*/), cgh);\n        sycl::local_accessor<sycl::half2, 2> deq2_acc_ct1(sycl::range<2>(256, 8), cgh);\n\n        sycl::half2 * vec_data_ptr_ct0 = (sycl::half2*) vec.data_ptr();\n        const int *__restrict mat_data_ptr_int_ct1 = mat.data_ptr<int>();\n        float *__restrict mul_data_ptr_float_ct2 = mul.data_ptr<float>();\n        const float *__restrict scales_data_ptr_float_ct3 = scales.data_ptr<float>();\n        const int *__restrict zeros_data_ptr_int_ct4 = zeros.data_ptr<int>();\n\n        cgh.parallel_for(\n          sycl::nd_range<3>(blocks * threads, threads), \n          [=](sycl::nd_item<3> item_ct1) {\n            VecQuant4MatMulKernelFaster_old(vec_data_ptr_ct0, mat_data_ptr_int_ct1, mul_data_ptr_float_ct2, scales_data_ptr_float_ct3, zeros_data_ptr_int_ct4, batch, vec_height, height, width, zero_width, groupsize, item_ct1, blockvec_acc_ct1.get_pointer(), deq2_acc_ct1);\n          });\n      });\n  }"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: true
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39157
+    Length:          1
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39162
+    Length:          11
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39222
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39494
+    Length:          0
+    ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1,\n    sycl::half2 *blockvec,\n    sycl::local_accessor<sycl::half2, 2> deq2"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39550
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(0)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39587
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39622
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(1)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39635
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39651
+    Length:          39
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39697
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39737
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39773
+    Length:          10
+    ReplacementText: 'item_ct1.get_group(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39800
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39817
+    Length:          30
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39860
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39889
+    Length:          11
+    ReplacementText: 'item_ct1.get_local_id(2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          39972
+    Length:          78
+    ReplacementText: 'sycl::half2(sycl::vec<int, 1>(val & 0xF).convert<sycl::half, sycl::rounding_mode::rte>()[0], sycl::vec<int, 1>(val >> 4).convert<sycl::half, sycl::rounding_mode::rte>()[0])'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          40181
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          40217
+    Length:          15
+    ReplacementText: "/*\n  DPCT1065:26: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n  */\n  item_ct1.barrier()"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          40349
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          40363
+    Length:          25
+    ReplacementText: 'sycl::float2(scale_f).convert<sycl::half, sycl::rounding_mode::rte>()'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          40394
+    Length:          5
+    ReplacementText: 'sycl::half2'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          40407
+    Length:          105
+    ReplacementText: 'sycl::float2(-(scale_f * ((((as_unsigned(zeros[g * zero_width + z_w]) >> z_mod) & 0xF) + 1) & 0x0f))).convert<sycl::half, sycl::rounding_mode::rte>()'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          40687
+    Length:          83
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp >>  0) & 0xff][off], scale, zero), blockvec[k + 0], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          40783
+    Length:          83
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp >>  8) & 0xff][off], scale, zero), blockvec[k + 1], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          40879
+    Length:          83
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp >> 16) & 0xff][off], scale, zero), blockvec[k + 2], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          40975
+    Length:          83
+    ReplacementText: 'sycl::fma(sycl::fma(deq2[(tmp >> 24) & 0xff][off], scale, zero), blockvec[k + 3], res2)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          41097
+    Length:          17
+    ReplacementText: 'res2[0]'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          41117
+    Length:          18
+    ReplacementText: 'res2[1]'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Offset:          41145
+    Length:          35
+    ReplacementText: 'dpct::atomic_fetch_add<sycl::access::address_space::generic_space>(&mul[b * width + w], res)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+MainSourceFilesDigest:
+  - MainSourceFile:  '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu'
+    Digest:          3e4e8809b639a94934d590b1bcc7a868
+DpctVersion:     2024.0.0
+MainHelperFileName: ''
+USMLevel:        ''
+FeatureMap:      {}
+CompileTargets:  {}
+OptionMap:
+  AnalysisScopePath:
+    Value:           '/home/majumder/gptq/AutoGPTQ/autogptq_extension/cuda_256'
+    Specified:       false
+  AsyncHandler:
+    Value:           'false'
+    Specified:       false
+  CommentsEnabled:
+    Value:           'false'
+    Specified:       false
+  CompilationsDir:
+    Value:           ''
+    Specified:       false
+  CtadEnabled:
+    Value:           'false'
+    Specified:       false
+  EnablepProfiling:
+    Value:           'false'
+    Specified:       false
+  ExperimentalFlag:
+    Value:           '0'
+    Specified:       false
+  ExplicitClNamespace:
+    Value:           'false'
+    Specified:       false
+  ExplicitNamespace:
+    Value:           '20'
+    Specified:       false
+  ExtensionDDFlag:
+    Value:           '0'
+    Specified:       false
+  ExtensionDEFlag:
+    Value:           '4294967295'
+    Specified:       false
+  HelperFuncPreferenceFlag:
+    Value:           '0'
+    Specified:       false
+  NDRangeDim:
+    Value:           '3'
+    Specified:       false
+  NoDRYPattern:
+    Value:           'false'
+    Specified:       false
+  NoUseGenericSpace:
+    Value:           ''
+    Specified:       true
+  OptimizeMigration:
+    Value:           'false'
+    Specified:       false
+  ProcessAll:
+    Value:           'true'
+    Specified:       true
+  RuleFile:
+    Value:           ''
+    Specified:       false
+  SyclNamedLambda:
+    Value:           'false'
+    Specified:       false
+  UsmLevel:
+    Value:           '1'
+    Specified:       false
+...

--- a/autogptq_extension/sycl/sycl_256/autogptq_sycl_256.cpp
+++ b/autogptq_extension/sycl/sycl_256/autogptq_sycl_256.cpp
@@ -1,0 +1,175 @@
+#include <torch/all.h>
+#include <torch/python.h>
+
+void vecquant2matmul_sycl(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  torch::Tensor g_idx
+);
+
+void vecquant2matmul(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  torch::Tensor g_idx
+) {
+  vecquant2matmul_sycl(vec, mat, mul, scales, zeros, g_idx);
+}
+
+void vecquant3matmul_sycl(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  torch::Tensor g_idx
+);
+
+void vecquant3matmul(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  torch::Tensor g_idx
+) {
+  vecquant3matmul_sycl(vec, mat, mul, scales, zeros, g_idx);
+}
+
+void vecquant4matmul_sycl(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  torch::Tensor g_idx
+);
+
+void vecquant4matmul(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  torch::Tensor g_idx
+) {
+  vecquant4matmul_sycl(vec, mat, mul, scales, zeros, g_idx);
+}
+
+void vecquant8matmul_sycl(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  torch::Tensor g_idx
+);
+
+void vecquant8matmul(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  torch::Tensor g_idx
+) {
+  vecquant8matmul_sycl(vec, mat, mul, scales, zeros, g_idx);
+}
+
+
+// old
+
+void vecquant2matmul_sycl_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize
+); 
+
+void vecquant2matmul_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize
+) {
+  vecquant2matmul_sycl_old(vec, mat, mul, scales, zeros,groupsize);
+}
+
+void vecquant3matmul_sycl_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize
+); 
+
+void vecquant3matmul_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize
+) {
+  vecquant3matmul_sycl_old(vec, mat, mul, scales, zeros, groupsize);
+}
+
+void vecquant4matmul_sycl_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize
+); 
+
+void vecquant4matmul_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize
+) {
+  vecquant4matmul_sycl_old(vec, mat, mul, scales, zeros, groupsize);
+}
+
+void vecquant8matmul_sycl_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize
+); 
+
+void vecquant8matmul_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize
+) {
+  vecquant8matmul_sycl_old(vec, mat, mul, scales, zeros, groupsize);
+}
+
+void vecquant2matmul_faster_sycl_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize, int vec_height
+); 
+
+void vecquant2matmul_faster_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize, int vec_height
+) {
+  vecquant2matmul_faster_sycl_old(vec, mat, mul, scales, zeros, groupsize, vec_height);
+}
+
+void vecquant3matmul_faster_sycl_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize, int vec_height
+); 
+
+void vecquant3matmul_faster_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize, int vec_height
+) {
+  vecquant3matmul_faster_sycl_old(vec, mat, mul, scales, zeros, groupsize, vec_height);
+}
+
+void vecquant4matmul_faster_sycl_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize, int vec_height
+); 
+
+void vecquant4matmul_faster_old(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor scales, torch::Tensor zeros,
+  int groupsize, int vec_height
+) {
+  vecquant4matmul_faster_sycl_old(vec, mat, mul, scales, zeros, groupsize, vec_height);
+}
+
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("vecquant2matmul", &vecquant2matmul, "Vector 2-bit Quantized Matrix Multiplication (sycl) (desc_act)");
+  m.def("vecquant3matmul", &vecquant3matmul, "Vector 3-bit Quantized Matrix Multiplication (sycl) (desc_act)");
+  m.def("vecquant4matmul", &vecquant4matmul, "Vector 4-bit Quantized Matrix Multiplication (sycl) (desc_act)");
+  m.def("vecquant8matmul", &vecquant8matmul, "Vector 8-bit Quantized Matrix Multiplication (sycl) (desc_act)");
+  
+  m.def("vecquant2matmul_old", &vecquant2matmul_old, "Vector 2-bit Quantized Matrix Multiplication (sycl)");
+  m.def("vecquant3matmul_old", &vecquant3matmul_old, "Vector 3-bit Quantized Matrix Multiplication (sycl)");
+  m.def("vecquant4matmul_old", &vecquant4matmul_old, "Vector 4-bit Quantized Matrix Multiplication (sycl)");
+  m.def("vecquant8matmul_old", &vecquant8matmul_old, "Vector 8-bit Quantized Matrix Multiplication (sycl)");
+  m.def("vecquant2matmul_faster_old", &vecquant2matmul_faster_old, "Vector 2-bit Quantized Matrix Multiplication (sycl), faster version");
+  m.def("vecquant3matmul_faster_old", &vecquant3matmul_faster_old, "Vector 3-bit Quantized Matrix Multiplication (sycl), faster version");
+  m.def("vecquant4matmul_faster_old", &vecquant4matmul_faster_old, "Vector 4-bit Quantized Matrix Multiplication (sycl), faster version");
+}

--- a/autogptq_extension/sycl/sycl_256/autogptq_sycl_kernel_256.cpp
+++ b/autogptq_extension/sycl/sycl_256/autogptq_sycl_kernel_256.cpp
@@ -1,0 +1,1883 @@
+#include <torch/all.h>
+#include <torch/python.h>
+#include <sycl/sycl.hpp>
+#include <dpct/dpct.hpp>
+#include "sycl_utils.h"
+
+
+typedef gptq::xpu::SyclTypeTrait<c10::Half> half;
+typedef dpct::atomic_compare_exchange_strong<sycl::access::address_space::generic_space> atomicCAS;
+typedef dpct::atomic_fetch_add<sycl::access::address_space::generic_space> atomicAdd;
+typedef sycl::ext::intel::math::hadd __hadd;
+
+// atomicAdd for double-precision floating-point numbers on hardware with
+// compute capability < 6.0 from:
+// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomic-functions
+// #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600
+// __device__ double atomicAdd(
+//     double* address,
+//     double val
+// ) {
+//   unsigned long long int* address_as_ull = (unsigned long long int*)address;
+//   unsigned long long int old = *address_as_ull, assumed;
+//
+//   do {
+//     assumed = old;
+//     old = atomicCAS(
+//       address_as_ull,
+//       assumed,
+//       __double_as_longlong(val + __longlong_as_double(assumed))
+//     );
+//
+//   // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
+//   } while (assumed != old);
+//
+//   return __longlong_as_double(old);
+// }
+// #endif
+
+#if (defined(DPCT_COMPATIBILITY_TEMP) && DPCT_COMPATIBILITY_TEMP < 700) || defined(USE_ROCM)
+// adapted from https://github.com/torch/cutorch/blob/master/lib/THC/THCAtomics.cuh
+
+inline void atomicAdd(half* address, half val) {
+    unsigned int *address_as_ui = reinterpret_cast<unsigned int *>(reinterpret_cast<char *>(address) - (reinterpret_cast<size_t>(address) & 2));
+    unsigned int old = *address_as_ui;
+    unsigned int assumed;
+
+    do {
+        assumed = old;
+        unsigned short hsum = reinterpret_cast<size_t>(address) & 2 ? (old >> 16) : (old & 0xffff);
+        hsum += val;
+        old = reinterpret_cast<size_t>(address) & 2
+                 ? (old & 0xffff) | (hsum << 16)
+                 : (old & 0xffff0000) | hsum;
+        old = atomicCAS(&address_as_ui[0], assumed, old);
+
+    // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
+    } while (assumed != old);
+}
+inline void atomicAdd(sycl::half* address, half val) {
+    unsigned int * address_as_ui = (unsigned int *) ((char *)address - ((size_t)address & 2));
+    unsigned int old = *address_as_ui;
+    unsigned int assumed;
+
+    do {
+        assumed = old;
+        uint16_t hsum;
+        hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+        half tmpres = __hadd(hsum, val);
+        hsum = uint16_t(tmpres);
+        old = (size_t)address & 2 ? (old & 0xffff) | (hsum.x << 16) : (old & 0xffff0000) | hsum.x;
+        old = atomicCAS(&address_as_ui[0], assumed, old);
+    } while (assumed != old);
+}
+#endif
+
+
+template <typename scalar_t>
+void VecQuant2MatMulKernel(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+	const  	    int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	int zero_width,
+	const sycl::nd_item<3> &item_ct1,
+	scalar_t *blockvec);
+
+template <typename scalar_t>
+void VecQuant3MatMulKernel(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+	const  	    int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	int zero_width,
+	const sycl::nd_item<3> &item_ct1,
+	scalar_t *blockvec);
+
+template <typename scalar_t>
+void VecQuant4MatMulKernel(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+	const  	    int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	int zero_width
+,
+	const sycl::nd_item<3> &item_ct1,
+	scalar_t *blockvec);
+
+template <typename scalar_t>
+void VecQuant8MatMulKernel(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+	const  	    int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	int zero_width,
+	const sycl::nd_item<3> &item_ct1,
+	scalar_t *blockvec);
+
+template <typename scalar_t>
+void VecQuant2MatMulKernel_old(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    scalar_t *blockvec);
+
+template <typename scalar_t>
+void VecQuant3MatMulKernel_old(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  	int* __restrict__ zeros,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    scalar_t *blockvec);
+
+template <typename scalar_t>
+void VecQuant4MatMulKernel_old(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  	int* __restrict__ zeros,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    scalar_t *blockvec);
+
+template <typename scalar_t>
+void VecQuant8MatMulKernel_old(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  	int* __restrict__ zeros,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    scalar_t *blockvec);
+
+void VecQuant2MatMulKernelFaster_old(
+    const  sycl::half2* __restrict__ vec,
+    const    int* __restrict__ mat,
+           float* __restrict__ mul,
+    const  float* __restrict__ scales,
+    const    int* __restrict__ zeros,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    sycl::half2 *blockvec,
+    sycl::local_accessor<sycl::half2, 2> deq2);
+
+void VecQuant3MatMulKernelFaster_old(
+    const  sycl::half2* __restrict__ vec,
+    const    int* __restrict__ mat,
+           float* __restrict__ mul,
+    const  float* __restrict__ scales,
+    const    int* __restrict__ zeros,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    sycl::half2 *blockvec,
+    sycl::local_accessor<sycl::half2, 2> deq2);
+
+void VecQuant4MatMulKernelFaster_old(
+    const  sycl::half2* __restrict__ vec,
+    const    int* __restrict__ mat,
+           float* __restrict__ mul,
+    const  float* __restrict__ scales,
+    const    int* __restrict__ zeros,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    sycl::half2 *blockvec,
+    sycl::local_accessor<sycl::half2, 2> deq2);
+
+
+const int BLOCKWIDTH  = 256;
+const int BLOCKHEIGHT2 =  16;
+const int BLOCKHEIGHT3 =  24;
+const int BLOCKHEIGHT4 =  32;
+const int BLOCKHEIGHT8 =  64;
+
+inline unsigned int as_unsigned(int i) {
+  return *reinterpret_cast<unsigned int*>(&i);
+}
+
+inline int as_int(int i) {
+  return *reinterpret_cast<int*>(&i);
+}
+
+
+void vecquant2matmul_sycl(
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  torch::Tensor g_idx
+) {
+  int batch = vec.size(0);
+  int vec_height = vec.size(1);
+  int height = mat.size(0);
+  int width = mat.size(1);
+  int zero_width = zeros.size(1);
+
+  AT_DISPATCH_FLOATING_TYPES(
+    vec.type(), "call_vecquant2matmul_sycl", ([&] {
+      call_vecquant2matmul_sycl<scalar_t>(
+        vec.data<scalar_t>(), mat.data<int>(), mul.data<scalar_t>(),
+        scales.data<scalar_t>(), zeros.data<int>(), g_idx.data<int>(),
+        batch, vec_height, height, width, zero_width
+      );
+    })
+  );
+}
+
+
+template <typename scalar_t>
+/*
+DPCT1110:0: The total declared local variable size in device function VecQuant2MatMulKernel exceeds 128 bytes and may cause high register pressure. Consult with your hardware vendor to find the total register size available and adjust the code, or use smaller sub-group size to avoid high register pressure.
+*/
+void VecQuant2MatMulKernel(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+    const   	int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	  int zero_width,
+	  const sycl::nd_item<3> &item_ct1,
+    scalar_t *blockvec) {
+ 
+  int h = BLOCKHEIGHT2 * item_ct1.get_group(2);
+  int w = BLOCKWIDTH * item_ct1.get_group(1) + item_ct1.get_local_id(2);
+
+  
+  int i = width * h + w;
+  int g_h = h * 16;
+  int k;
+  unsigned int g;
+  scalar_t w_tmp;
+
+  int z_w = w / 16;
+  int z_mod = (w % 16) * 2;
+
+  float weight[BLOCKWIDTH];
+
+  for (k = 0; k <  BLOCKWIDTH; ++k){
+	int k_w = (k / 16);
+	int k_bit = (k % 16) * 2;
+
+  g = as_int(g_idx[g_h + k]);
+  scalar_t scale = scales[g * width + w];
+
+  // Avoid overflows with & 0x0f.
+  scalar_t zero = scalar_t(((as_unsigned(zeros[g * zero_width + z_w]) >> z_mod & 0x3) + 1) & 0x0f);
+
+  w_tmp = ((as_unsigned(mat[i + (k_w * width)]) >> k_bit) & 0x3);
+
+	weight[k] = scale * (w_tmp - zero);
+  }
+
+  scalar_t res;
+  for (int b = 0; b < batch; ++b){
+	res = 0;
+
+    blockvec[item_ct1.get_local_id(2)] = vec[b * vec_height + item_ct1.get_group(2) * BLOCKWIDTH + item_ct1.get_local_id(2)];
+    
+    item_ct1.barrier(sycl::access::fence_space::local_space);
+	for (k = 0; k <  BLOCKWIDTH; ++k){
+	  res += weight[k] * blockvec[k];
+    }
+    atomicAdd(&mul[b * width + w], res);
+    
+    item_ct1.barrier(sycl::access::fence_space::local_space);
+  }
+}
+
+
+template <typename scalar_t>
+void call_vecquant2matmul_sycl(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+    const   	int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	 int zero_width
+){
+
+
+   using sycl_t = gptq::xpu::SyclTypeTrait<scalar_t>::Type;
+   sycl::range<3> block(1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2);
+   sycl::range<3> threads(1, 1, BLOCKWIDTH); //grid
+   auto& q_ct1 = gptq::xpu::gptqGetQueue();
+   q_ct1.submit([&](sycl::handler& cgh) {
+      sycl::local_accessor<sycl_t, 1> blockvec(sycl::range<1>(BLOCKWIDTH), cgh);
+      cgh.parallel_for(
+          sycl::nd_range<3>(blocks * threads, threads),
+          [=](sycl::nd_item<3> item_ct1) {
+            VecQuant2MatMulKernel<sycl_t>(
+                (const sycl_t* __restrict__)vec,
+                (const int* __restrict__)mat,
+                (sycl_t* __restrict__)mul,
+                (const sycl_t* __restrict__)scales,
+                (const int* __restrict__)zeros,
+                (const int* __restrict__)g_idx,
+                batch,
+                vec_height,
+                height,
+                width,
+                zero_width,
+                item_ct1,
+                blockvec.get_pointer());
+          });
+    });
+
+}
+
+
+void vecquant3matmul_sycl(
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  torch::Tensor g_idx
+) {
+  int batch = vec.size(0);
+  int vec_height = vec.size(1);
+  int height = mat.size(0);
+  int width = mat.size(1);
+  int zero_width = zeros.size(1);
+
+  AT_DISPATCH_FLOATING_TYPES(
+    vec.type(), "call_vecquant3matmul_sycl", ([&] {
+      call_vecquant3matmul_sycl<scalar_t>(
+        vec.data<scalar_t>(), mat.data<int>(), mul.data<scalar_t>(),
+        scales.data<scalar_t>(), zeros.data<int>(), g_idx.data<int>(),
+        batch, vec_height, height, width, zero_width
+      );
+    })
+  );
+}
+
+template <typename scalar_t>
+/*
+DPCT1110:3: The total declared local variable size in device function VecQuant3MatMulKernel exceeds 128 bytes and may cause high register pressure. Consult with your hardware vendor to find the total register size available and adjust the code, or use smaller sub-group size to avoid high register pressure.
+*/
+void VecQuant3MatMulKernel(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const       int* __restrict__ zeros,
+    const   	int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	  int zero_width,
+	  const sycl::nd_item<3> &item_ct1,
+	  scalar_t *blockvec) {
+     
+  int h = BLOCKHEIGHT3 * item_ct1.get_group(2);
+  int w = BLOCKWIDTH * item_ct1.get_group(1) + item_ct1.get_local_id(2);
+
+  
+  int i = width * h + w;
+  int g_h = (h / 3) * 32;
+  int k;
+  unsigned int g;
+  scalar_t w_tmp;
+
+  int z_w = (w / 32) * 3;
+  int z_mod = w % 32;
+  int z_bit;
+  unsigned int z_tmp;
+  if (z_mod != 10){
+    if (z_mod != 21){
+      z_bit = z_mod;
+      if (z_bit > 21){
+        z_bit -= 22;
+        z_bit *= 3;
+        z_bit += 2;
+        z_w += 2;
+      } else if (z_bit > 10){
+        z_bit -= 11;
+        z_bit *= 3;
+        z_bit += 1;
+        z_w += 1;
+      } else {
+        z_bit *= 3;
+      }
+    } else {
+      z_w += 1;
+    }
+  }
+
+  float weight[BLOCKWIDTH];
+
+  for (k = 0; k <  BLOCKWIDTH; ++k){
+	int k_w = (k / 32) * 3;
+	int k_mod = k % 32;
+	int k_bit;
+
+	if (k_mod != 10){
+	  if (k_mod != 21){
+        k_bit = k_mod;
+        if (k_bit > 21){
+		  k_bit -= 22;
+		  k_bit *= 3;
+		  k_bit += 2;
+		  k_w += 2;
+        } else if (k_bit > 10){
+		  k_bit -= 11;
+		  k_bit *= 3;
+		  k_bit += 1;
+		  k_w += 1;
+        } else {
+		  k_bit *= 3;
+        }
+	  } else {
+        k_w += 1;
+	  }
+	}
+
+    g = as_int(g_idx[g_h + k]);
+    scalar_t scale = scales[g * width + w];
+    scalar_t zero;
+    if (z_mod == 10) {
+      z_tmp = (as_unsigned(zeros[g * zero_width + z_w]) >> 30) | ((as_unsigned(zeros[g * zero_width + (z_w + 1)]) << 2) & 0x4);
+      zero = scalar_t(((z_tmp) + 1) & 0x0f);  // Avoid overflows
+    } else if (z_mod == 21){
+      z_tmp = (as_unsigned(zeros[g * zero_width + z_w]) >> 31) | ((as_unsigned(zeros[g * zero_width + (z_w + 1)]) << 1) & 0x6);
+      zero = scalar_t(((z_tmp) + 1) & 0x0f);
+    } else {
+      zero = scalar_t((((as_unsigned(zeros[g * zero_width + z_w]) >> z_bit) & 0x7) + 1) & 0x0f);
+    }
+
+    if (k_mod == 10) {
+      w_tmp = (as_unsigned(mat[i + (k_w * width)]) >> 30) | ((as_unsigned(mat[i + ((k_w + 1)* width)]) << 2) & 0x4);
+    } else if (k_mod == 21){
+      w_tmp = (as_unsigned(mat[i + (k_w * width)]) >> 31) | ((as_unsigned(mat[i + ((k_w + 1)* width)]) << 1) & 0x6);
+    } else {
+      w_tmp = ((as_unsigned(mat[i + (k_w * width)]) >> k_bit) & 0x7);
+    }
+	weight[k] = scale * (w_tmp - zero);
+  }
+
+  scalar_t res;
+  for (int b = 0; b < batch; ++b){
+	res = 0;
+
+    blockvec[item_ct1.get_local_id(2)] = vec[b * vec_height + item_ct1.get_group(2) * BLOCKWIDTH + item_ct1.get_local_id(2)];
+
+    item_ct1.barrier(sycl::access::fence_space::local_space);
+	for (k = 0; k <  BLOCKWIDTH; ++k){
+	  res += weight[k] * blockvec[k];
+    }
+    atomicAdd(&mul[b * width + w], res);
+
+    item_ct1.barrier(sycl::access::fence_space::local_space);
+  }
+}
+
+
+template <typename scalar_t>
+void call_vecquant3matmul_sycl(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+    const   	int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	 int zero_width
+){
+
+
+   using sycl_t = gptq::xpu::SyclTypeTrait<scalar_t>::Type;
+   sycl::range<3> blocks(1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2);
+   sycl::range<3> threads(1, 1, BLOCKWIDTH); //grid
+   auto& q_ct1 = gptq::xpu::gptqGetQueue();
+   q_ct1.submit([&](sycl::handler& cgh) {
+      sycl::local_accessor<sycl_t, 1> blockvec(sycl::range<1>(BLOCKWIDTH), cgh);
+      cgh.parallel_for(
+          sycl::nd_range<3>(blocks * threads, threads),
+          [=](sycl::nd_item<3> item_ct1) {
+            VecQuant3MatMulKernel<sycl_t>(
+                (const sycl_t* __restrict__)vec,
+                (const int* __restrict__)mat,
+                (sycl_t* __restrict__)mul,
+                (const sycl_t* __restrict__)scales,
+                (const int* __restrict__)zeros,
+                (const int* __restrict__)g_idx,
+                batch,
+                vec_height,
+                height,
+                width,
+                zero_width,
+                item_ct1,
+                blockvec.get_pointer());
+          });
+    });
+
+}
+
+void vecquant4matmul_sycl(
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  torch::Tensor g_idx
+) {
+  int batch = vec.size(0);
+  int vec_height = vec.size(1);
+  int height = mat.size(0);
+  int width = mat.size(1);
+  int zero_width = zeros.size(1);
+
+  AT_DISPATCH_FLOATING_TYPES(
+    vec.type(), "call_vecquant4matmul_sycl", ([&] {
+      call_vecquant4matmul_sycl<scalar_t>(
+        vec.data<scalar_t>(), mat.data<int>(), mul.data<scalar_t>(),
+        scales.data<scalar_t>(), zeros.data<int>(), g_idx.data<int>(),
+        batch, vec_height, height, width, zero_width
+      );
+    })
+  );
+}
+
+template <typename scalar_t>
+/*
+DPCT1110:6: The total declared local variable size in device function VecQuant4MatMulKernel exceeds 128 bytes and may cause high register pressure. Consult with your hardware vendor to find the total register size available and adjust the code, or use smaller sub-group size to avoid high register pressure.
+*/
+void VecQuant4MatMulKernel(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const       int* __restrict__ zeros,
+    const   	int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	  int zero_width,
+	  const sycl::nd_item<3> &item_ct1,
+	  scalar_t *blockvec) {
+  
+  int h = BLOCKHEIGHT4 * item_ct1.get_group(2);
+  int w = BLOCKWIDTH * item_ct1.get_group(1) + item_ct1.get_local_id(2);
+
+  
+  int i = width * h + w;
+  int g_h = h * 8;
+  int k;
+  unsigned int g;
+  scalar_t w_tmp;
+
+
+  int z_w = w / 8;
+  int z_mod = (w % 8) * 4;
+
+  float weight[BLOCKWIDTH];
+
+  for (k = 0; k <  BLOCKWIDTH; ++k){
+	int k_w = (k / 8);
+	int k_bit = (k % 8) * 4;
+
+    g = as_int(g_idx[g_h + k]);
+    scalar_t scale = scales[g * width + w];
+    scalar_t zero = scalar_t((((as_unsigned(zeros[g * zero_width + z_w]) >> z_mod) & 0xF) + 1) & 0x0f);
+
+    w_tmp = ((as_unsigned(mat[i + (k_w * width)]) >> k_bit) & 0xF);
+
+	weight[k] = scale * (w_tmp - zero);
+  }
+
+  scalar_t res;
+  for (int b = 0; b < batch; ++b){
+	res = 0;
+
+    blockvec[item_ct1.get_local_id(2)] = vec[b * vec_height + item_ct1.get_group(2) * BLOCKWIDTH + item_ct1.get_local_id(2)];
+    
+    item_ct1.barrier(sycl::access::fence_space::local_space);
+	for (k = 0; k <  BLOCKWIDTH; ++k){
+	  res += weight[k] * blockvec[k];
+    }
+    
+    atomicAdd(&mul[b * width + w], res);
+    
+    item_ct1.barrier(sycl::access::fence_space::local_space);
+  }
+}
+
+
+template <typename scalar_t>
+void call_vecquant4matmul_sycl(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+    const   	int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	 int zero_width
+){
+
+
+   using sycl_t = gptq::xpu::SyclTypeTrait<scalar_t>::Type;
+   sycl::range<3> blocks(1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2);
+   sycl::range<3> threads(1, 1, BLOCKWIDTH); //grid
+   auto& q_ct1 = gptq::xpu::gptqGetQueue();
+   q_ct1.submit([&](sycl::handler& cgh) {
+      sycl::local_accessor<sycl_t, 1> blockvec(sycl::range<1>(BLOCKWIDTH), cgh);
+      cgh.parallel_for(
+          sycl::nd_range<3>(blocks * threads, threads),
+          [=](sycl::nd_item<3> item_ct1) {
+            VecQuant4MatMulKernel<sycl_t>(
+                (const sycl_t* __restrict__)vec,
+                (const int* __restrict__)mat,
+                (sycl_t* __restrict__)mul,
+                (const sycl_t* __restrict__)scales,
+                (const int* __restrict__)zeros,
+                (const int* __restrict__)g_idx,
+                batch,
+                vec_height,
+                height,
+                width,
+                zero_width,
+                item_ct1,
+                blockvec.get_pointer());
+          });
+    });
+
+}
+
+void vecquant8matmul_sycl(
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  torch::Tensor g_idx
+) {
+  int batch = vec.size(0);
+  int vec_height = vec.size(1);
+  int height = mat.size(0);
+  int width = mat.size(1);
+  int zero_width = zeros.size(1);
+
+  AT_DISPATCH_FLOATING_TYPES(
+    vec.type(), "call_vecquant8matmul_sycl", ([&] {
+      call_vecquant8matmul_sycl<scalar_t>(
+        vec.data<scalar_t>(), mat.data<int>(), mul.data<scalar_t>(),
+        scales.data<scalar_t>(), zeros.data<int>(), g_idx.data<int>(),
+        batch, vec_height, height, width, zero_width
+      );
+    })
+  );
+}
+
+template <typename scalar_t>
+/*
+DPCT1110:9: The total declared local variable size in device function VecQuant8MatMulKernel exceeds 128 bytes and may cause high register pressure. Consult with your hardware vendor to find the total register size available and adjust the code, or use smaller sub-group size to avoid high register pressure.
+*/
+void VecQuant8MatMulKernel(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const       int* __restrict__ zeros,
+    const   	int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	  int zero_width,
+	  const sycl::nd_item<3> &item_ct1,
+	  scalar_t *blockvec) {
+     
+  int h = BLOCKHEIGHT8 * item_ct1.get_group(2);
+  int w = BLOCKWIDTH * item_ct1.get_group(1) + item_ct1.get_local_id(2);
+
+  
+  int i = width * h + w;
+  int g_h = h * 4;
+  int k;
+  unsigned int g;
+  scalar_t w_tmp;
+
+  int z_w = w / 4;
+  int z_mod = (w % 4) * 8;
+
+  float weight[BLOCKWIDTH];
+
+  for (k = 0; k <  BLOCKWIDTH; ++k){
+	int k_w = (k / 4);
+	int k_bit = (k % 4) * 8;
+
+    g = as_int(g_idx[g_h + k]);
+    scalar_t scale = scales[g * width + w];
+    scalar_t zero = scalar_t((((as_unsigned(zeros[g * zero_width + z_w]) >> z_mod) & 0xFF) + 1) & 0x0f);
+
+    w_tmp = ((as_unsigned(mat[i + (k_w * width)]) >> k_bit) & 0xFF);
+
+	weight[k] = scale * (w_tmp - zero);
+  }
+
+  scalar_t res;
+  for (int b = 0; b < batch; ++b){
+	res = 0;
+
+    blockvec[item_ct1.get_local_id(2)] = vec[b * vec_height + item_ct1.get_group(2) * BLOCKWIDTH + item_ct1.get_local_id(2)];
+    
+    item_ct1.barrier(sycl::access::fence_space::local_space);
+	for (k = 0; k <  BLOCKWIDTH; ++k){
+	  res += weight[k] * blockvec[k];
+    }
+    atomicAdd(&mul[b * width + w], res);
+    
+    item_ct1.barrier(sycl::access::fence_space::local_space);
+  }
+}
+
+template <typename scalar_t>
+void call_vecquant8matmul_sycl(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+    const   	int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	 int zero_width
+){
+
+
+   using sycl_t = gptq::xpu::SyclTypeTrait<scalar_t>::Type;
+   sycl::range<3> blocks(1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2);
+   sycl::range<3> threads(1, 1, BLOCKWIDTH); //grid
+   auto& q_ct1 = gptq::xpu::gptqGetQueue();
+   q_ct1.submit([&](sycl::handler& cgh) {
+      sycl::local_accessor<sycl_t, 1> blockvec(sycl::range<1>(BLOCKWIDTH), cgh);
+      cgh.parallel_for(
+          sycl::nd_range<3>(blocks * threads, threads),
+          [=](sycl::nd_item<3> item_ct1) {
+            VecQuant8MatMulKernel<sycl_t>(
+                (const sycl_t* __restrict__)vec,
+                (const int* __restrict__)mat,
+                (sycl_t* __restrict__)mul,
+                (const sycl_t* __restrict__)scales,
+                (const int* __restrict__)zeros,
+                (const int* __restrict__)g_idx,
+                batch,
+                vec_height,
+                height,
+                width,
+                zero_width,
+                item_ct1,
+                blockvec.get_pointer());
+          });
+    });
+
+}
+
+
+void vecquant2matmul_sycl_old(
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  int groupsize
+) {
+  int batch = vec.size(0);
+  int vec_height = vec.size(1);
+  int height = mat.size(0);
+  int width = mat.size(1);
+  int zero_width = zeros.size(1);
+
+  AT_DISPATCH_FLOATING_TYPES(
+    vec.type(), "call_vecquant2matmul_sycl_old", ([&] {
+      call_vecquant2matmul_sycl_old<scalar_t>(
+        vec.data<scalar_t>(), mat.data<int>(), mul.data<scalar_t>(),
+        scales.data<scalar_t>(), zeros.data<int>(),
+        batch, vec_height, height, width, zero_width, groupsize
+      );
+    })
+  );
+}
+
+template <typename scalar_t>
+void VecQuant2MatMulKernel_old(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  	int* __restrict__ zeros,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    scalar_t *blockvec) {
+  
+  int b = item_ct1.get_group(0);
+  int h = BLOCKHEIGHT2 * item_ct1.get_group(2);
+  int w = BLOCKWIDTH * item_ct1.get_group(1) + item_ct1.get_local_id(2);
+
+  
+  blockvec[item_ct1.get_local_id(2)] = vec[b * vec_height + item_ct1.get_group(2) * BLOCKWIDTH + item_ct1.get_local_id(2)];
+  
+  item_ct1.barrier(sycl::access::fence_space::local_space);
+
+  scalar_t res = 0;
+  int i = width * h + w;
+  int g_h = h * 16;
+  int k = 0;
+
+  int z_w = w / 16;
+  int z_mod = (w % 16) * 2;
+
+  unsigned int tmp;
+
+  while (k < BLOCKWIDTH) {
+    tmp = as_unsigned(mat[i]);
+
+    int g = (g_h + k) / groupsize;
+    scalar_t scale = scales[g * width + w];
+    scalar_t zero = scale * scalar_t(((as_unsigned(zeros[g * zero_width + z_w]) >> z_mod & 0x3) + 1) & 0x0f);
+
+    res += (scale * scalar_t((tmp >> 0) & 0x3) - zero) * blockvec[k + 0];
+    res += (scale * scalar_t((tmp >> 2) & 0x3) - zero) * blockvec[k + 1];
+    res += (scale * scalar_t((tmp >> 4) & 0x3) - zero) * blockvec[k + 2];
+    res += (scale * scalar_t((tmp >> 6) & 0x3) - zero) * blockvec[k + 3];
+    res += (scale * scalar_t((tmp >> 8) & 0x3) - zero) * blockvec[k + 4];
+    res += (scale * scalar_t((tmp >> 10) & 0x3) - zero) * blockvec[k + 5];
+    res += (scale * scalar_t((tmp >> 12) & 0x3) - zero) * blockvec[k + 6];
+    res += (scale * scalar_t((tmp >> 14) & 0x3) - zero) * blockvec[k + 7];
+    res += (scale * scalar_t((tmp >> 16) & 0x3) - zero) * blockvec[k + 8];
+    res += (scale * scalar_t((tmp >> 18) & 0x3) - zero) * blockvec[k + 9];
+    res += (scale * scalar_t((tmp >> 20) & 0x3) - zero) * blockvec[k + 10];
+    res += (scale * scalar_t((tmp >> 22) & 0x3) - zero) * blockvec[k + 11];
+    res += (scale * scalar_t((tmp >> 24) & 0x3) - zero) * blockvec[k + 12];
+    res += (scale * scalar_t((tmp >> 26) & 0x3) - zero) * blockvec[k + 13];
+    res += (scale * scalar_t((tmp >> 28) & 0x3) - zero) * blockvec[k + 14];
+    res += (scale * scalar_t((tmp >> 30) & 0x3) - zero) * blockvec[k + 15];
+
+    i += width;
+    k += 16;
+  }
+
+  atomicAdd(&mul[b * width + w], res);
+}
+
+
+template <typename scalar_t>
+void call_vecquant2matmul_sycl_old(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+    const   	int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	 int zero_width,
+    int groupsize
+){
+
+
+   using sycl_t = gptq::xpu::SyclTypeTrait<scalar_t>::Type;
+   sycl::range<3> blocks(1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2);
+   sycl::range<3> threads(1, 1, BLOCKWIDTH); //grid
+   auto& q_ct1 = gptq::xpu::gptqGetQueue();
+   q_ct1.submit([&](sycl::handler& cgh) {
+      sycl::local_accessor<sycl_t, 1> blockvec(sycl::range<1>(BLOCKWIDTH), cgh);
+      cgh.parallel_for(
+          sycl::nd_range<3>(blocks * threads, threads),
+          [=](sycl::nd_item<3> item_ct1) {
+            VecQuant2MatMulKernel_old<sycl_t>(
+                (const sycl_t* __restrict__)vec,
+                (const int* __restrict__)mat,
+                (sycl_t* __restrict__)mul,
+                (const sycl_t* __restrict__)scales,
+                (const int* __restrict__)zeros,
+                (const int* __restrict__)g_idx,
+                batch,
+                vec_height,
+                height,
+                width,
+                zero_width,
+                groupsize,
+                item_ct1,
+                blockvec.get_pointer());
+          });
+    });
+
+}
+
+
+void vecquant3matmul_sycl_old(
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  int groupsize
+) {
+  int batch = vec.size(0);
+  int vec_height = vec.size(1);
+  int height = mat.size(0);
+  int width = mat.size(1);
+  int zero_width = zeros.size(1);
+
+  AT_DISPATCH_FLOATING_TYPES(
+    vec.type(), "call_vecquant3matmul_sycl_old", ([&] {
+      call_vecquant3matmul_sycl_old<scalar_t>(
+        vec.data<scalar_t>(), mat.data<int>(), mul.data<scalar_t>(),
+        scales.data<scalar_t>(), zeros.data<int>(),
+        batch, vec_height, height, width, zero_width, groupsize
+      );
+    })
+  );
+}
+
+template <typename scalar_t>
+void VecQuant3MatMulKernel_old(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  	int* __restrict__ zeros,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    scalar_t *blockvec) {
+  
+  int b = item_ct1.get_group(0);
+  int h = BLOCKHEIGHT3 * item_ct1.get_group(2);
+  int w = BLOCKWIDTH * item_ct1.get_group(1) + item_ct1.get_local_id(2);
+
+  
+  blockvec[item_ct1.get_local_id(2)] = vec[b * vec_height + item_ct1.get_group(2) * BLOCKWIDTH + item_ct1.get_local_id(2)];
+  
+  item_ct1.barrier(sycl::access::fence_space::local_space);
+
+  scalar_t res = 0;
+  int i = width * h + w;
+  int g_h = (h / 3) * 32;
+  int k = 0;
+
+  int z_w = (w / 32) * 3;
+  int z_mod = w % 32;
+  int z_bit;
+
+  if (z_mod != 10){
+    if (z_mod != 21){
+      z_bit = z_mod;
+      if (z_bit > 21){
+        z_bit -= 22;
+        z_bit *= 3;
+        z_bit += 2;
+        z_w += 2;
+      } else if (z_bit > 10){
+        z_bit -= 11;
+        z_bit *= 3;
+        z_bit += 1;
+        z_w += 1;
+      } else {
+        z_bit *= 3;
+      }
+    } else {
+      z_w += 1;
+    }
+  }
+
+  unsigned int tmp1;
+  unsigned int tmp2;
+  unsigned int tmp;
+  unsigned int z_tmp;
+
+  while (k < BLOCKWIDTH) {
+    tmp1 = as_unsigned(mat[i]);
+
+    int g = (g_h + k) / groupsize;
+    scalar_t scale = scales[g * width + w];
+    scalar_t zero;
+    if (z_mod == 10) {
+      z_tmp = (as_unsigned(zeros[g * zero_width + z_w]) >> 30) | ((as_unsigned(zeros[g * zero_width + (z_w + 1)]) << 2) & 0x4);
+      zero = scale * scalar_t(((z_tmp) + 1) & 0x0f);
+    } else if (z_mod == 21){
+      z_tmp = (as_unsigned(zeros[g * zero_width + z_w]) >> 31) | ((as_unsigned(zeros[g * zero_width + (z_w + 1)]) << 1) & 0x6);
+      zero = scale * scalar_t(((z_tmp) + 1) & 0x0f);
+    } else {
+      zero = scale * scalar_t((((as_unsigned(zeros[g * zero_width + z_w]) >> z_bit) & 0x7) + 1) & 0x0f);
+    }
+
+    res += (scale * scalar_t((tmp1 >>  0) & 0x7) - zero) * blockvec[k + 0];
+    res += (scale * scalar_t((tmp1 >>  3) & 0x7) - zero) * blockvec[k + 1];
+    res += (scale * scalar_t((tmp1 >>  6) & 0x7) - zero) * blockvec[k + 2];
+    res += (scale * scalar_t((tmp1 >>  9) & 0x7) - zero) * blockvec[k + 3];
+    res += (scale * scalar_t((tmp1 >> 12) & 0x7) - zero) * blockvec[k + 4];
+    res += (scale * scalar_t((tmp1 >> 15) & 0x7) - zero) * blockvec[k + 5];
+    res += (scale * scalar_t((tmp1 >> 18) & 0x7) - zero) * blockvec[k + 6];
+    res += (scale * scalar_t((tmp1 >> 21) & 0x7) - zero) * blockvec[k + 7];
+    res += (scale * scalar_t((tmp1 >> 24) & 0x7) - zero) * blockvec[k + 8];
+    res += (scale * scalar_t((tmp1 >> 27) & 0x7) - zero) * blockvec[k + 9];
+
+    i += width;
+    tmp2 = as_unsigned(mat[i]);
+    tmp = (tmp1 >> 30) | ((tmp2 << 2) & 0x4);
+    tmp2 >>= 1;
+    res += (scale * scalar_t(tmp) - zero) * blockvec[k + 10];
+    k += 11;
+
+    res += (scale * scalar_t((tmp2 >>  0) & 0x7) - zero) * blockvec[k + 0];
+    res += (scale * scalar_t((tmp2 >>  3) & 0x7) - zero) * blockvec[k + 1];
+    res += (scale * scalar_t((tmp2 >>  6) & 0x7) - zero) * blockvec[k + 2];
+    res += (scale * scalar_t((tmp2 >>  9) & 0x7) - zero) * blockvec[k + 3];
+    res += (scale * scalar_t((tmp2 >> 12) & 0x7) - zero) * blockvec[k + 4];
+    res += (scale * scalar_t((tmp2 >> 15) & 0x7) - zero) * blockvec[k + 5];
+    res += (scale * scalar_t((tmp2 >> 18) & 0x7) - zero) * blockvec[k + 6];
+    res += (scale * scalar_t((tmp2 >> 21) & 0x7) - zero) * blockvec[k + 7];
+    res += (scale * scalar_t((tmp2 >> 24) & 0x7) - zero) * blockvec[k + 8];
+    res += (scale * scalar_t((tmp2 >> 27) & 0x7) - zero) * blockvec[k + 9];
+
+    i += width;
+    tmp1 = as_unsigned(mat[i]);
+    tmp = (tmp2 >> 30) | ((tmp1 << 1) & 0x6);
+    tmp1 >>= 2;
+    res += (scale * scalar_t(tmp) - zero) * blockvec[k + 10];
+    k += 11;
+
+    res += (scale * scalar_t((tmp1 >>  0) & 0x7) - zero) * blockvec[k + 0];
+    res += (scale * scalar_t((tmp1 >>  3) & 0x7) - zero) * blockvec[k + 1];
+    res += (scale * scalar_t((tmp1 >>  6) & 0x7) - zero) * blockvec[k + 2];
+    res += (scale * scalar_t((tmp1 >>  9) & 0x7) - zero) * blockvec[k + 3];
+    res += (scale * scalar_t((tmp1 >> 12) & 0x7) - zero) * blockvec[k + 4];
+    res += (scale * scalar_t((tmp1 >> 15) & 0x7) - zero) * blockvec[k + 5];
+    res += (scale * scalar_t((tmp1 >> 18) & 0x7) - zero) * blockvec[k + 6];
+    res += (scale * scalar_t((tmp1 >> 21) & 0x7) - zero) * blockvec[k + 7];
+    res += (scale * scalar_t((tmp1 >> 24) & 0x7) - zero) * blockvec[k + 8];
+    res += (scale * scalar_t((tmp1 >> 27) & 0x7) - zero) * blockvec[k + 9];
+
+    i += width;
+    k += 10;
+  }
+
+  atomicAdd(&mul[b * width + w], res);
+}
+
+
+template <typename scalar_t>
+void call_vecquant3matmul_sycl_old(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+    const   	int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	 int zero_width,
+    int groupsize
+){
+
+
+   using sycl_t = gptq::xpu::SyclTypeTrait<scalar_t>::Type;
+   sycl::range<3> blocks(1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2);
+   sycl::range<3> threads(1, 1, BLOCKWIDTH); //grid
+   auto& q_ct1 = gptq::xpu::gptqGetQueue();
+   q_ct1.submit([&](sycl::handler& cgh) {
+      sycl::local_accessor<sycl_t, 1> blockvec(sycl::range<1>(BLOCKWIDTH), cgh);
+      cgh.parallel_for(
+          sycl::nd_range<3>(blocks * threads, threads),
+          [=](sycl::nd_item<3> item_ct1) {
+            VecQuant3MatMulKernel_old<sycl_t>(
+                (const sycl_t* __restrict__)vec,
+                (const int* __restrict__)mat,
+                (sycl_t* __restrict__)mul,
+                (const sycl_t* __restrict__)scales,
+                (const int* __restrict__)zeros,
+                (const int* __restrict__)g_idx,
+                batch,
+                vec_height,
+                height,
+                width,
+                zero_width,
+                groupsize,
+                item_ct1,
+                blockvec.get_pointer());
+          });
+    });
+
+}
+
+
+
+void vecquant4matmul_sycl_old(
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  int groupsize
+) {
+  int batch = vec.size(0);
+  int vec_height = vec.size(1);
+  int height = mat.size(0);
+  int width = mat.size(1);
+  int zero_width = zeros.size(1);
+
+  
+  AT_DISPATCH_FLOATING_TYPES(
+    vec.type(), "vecquant4matmul_sycl_old", ([&] {
+      call_vecquant4matmul_sycl_old<scalar_t>(
+        vec.data<scalar_t>(), mat.data<int>(), mul.data<scalar_t>(),
+        scales.data<scalar_t>(), zeros.data<int>(),
+        batch, vec_height, height, width, zero_width, groupsize
+      );
+    })
+  );
+}
+
+template <typename scalar_t>
+void VecQuant4MatMulKernel_old(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const       int* __restrict__ zeros,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    scalar_t *blockvec) {
+  
+  int b = item_ct1.get_group(0);
+  int h = BLOCKHEIGHT4 * item_ct1.get_group(2);
+  int w = BLOCKWIDTH * item_ct1.get_group(1) + item_ct1.get_local_id(2);
+
+  
+  blockvec[item_ct1.get_local_id(2)] = vec[b * vec_height + item_ct1.get_group(2) * BLOCKWIDTH + item_ct1.get_local_id(2)];
+  
+  item_ct1.barrier(sycl::access::fence_space::local_space);
+
+  scalar_t res = 0;
+  int i = width * h + w;
+  int g_h = h * 8;
+  int k = 0;
+
+  int z_w = w / 8;
+  int z_mod = (w % 8) * 4;
+
+  unsigned int tmp;
+
+  while (k < BLOCKWIDTH) {
+    tmp = as_unsigned(mat[i]);
+
+    int g = (g_h + k) / groupsize;
+    scalar_t scale = scales[g * width + w];
+    scalar_t zero = scale * scalar_t((((as_unsigned(zeros[g * zero_width + z_w]) >> z_mod) & 0xF) + 1) & 0x0f);
+
+    res += (scale * scalar_t((tmp >> 0) & 0xF) - zero) * blockvec[k + 0];
+    res += (scale * scalar_t((tmp >> 4) & 0xF) - zero) * blockvec[k + 1];
+    res += (scale * scalar_t((tmp >> 8) & 0xF) - zero) * blockvec[k + 2];
+    res += (scale * scalar_t((tmp >> 12) & 0xF) - zero) * blockvec[k + 3];
+    res += (scale * scalar_t((tmp >> 16) & 0xF) - zero) * blockvec[k + 4];
+    res += (scale * scalar_t((tmp >> 20) & 0xF) - zero) * blockvec[k + 5];
+    res += (scale * scalar_t((tmp >> 24) & 0xF) - zero) * blockvec[k + 6];
+    res += (scale * scalar_t((tmp >> 28) & 0xF) - zero) * blockvec[k + 7];
+
+    i += width;
+    k += 8;
+  }
+
+  atomicAdd(&mul[b * width + w], res);
+}
+
+
+template <typename scalar_t>
+void call_vecquant4matmul_sycl_old(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+    const   	int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	 int zero_width,
+    int groupsize
+){
+
+
+   using sycl_t = gptq::xpu::SyclTypeTrait<scalar_t>::Type;
+   sycl::range<3> blocks(1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2);
+   sycl::range<3> threads(1, 1, BLOCKWIDTH); //grid
+   auto& q_ct1 = gptq::xpu::gptqGetQueue();
+   q_ct1.submit([&](sycl::handler& cgh) {
+      sycl::local_accessor<sycl_t, 1> blockvec(sycl::range<1>(BLOCKWIDTH), cgh);
+      cgh.parallel_for(
+          sycl::nd_range<3>(blocks * threads, threads),
+          [=](sycl::nd_item<3> item_ct1) {
+            VecQuant4MatMulKernel_old<sycl_t>(
+                (const sycl_t* __restrict__)vec,
+                (const int* __restrict__)mat,
+                (sycl_t* __restrict__)mul,
+                (const sycl_t* __restrict__)scales,
+                (const int* __restrict__)zeros,
+                (const int* __restrict__)g_idx,
+                batch,
+                vec_height,
+                height,
+                width,
+                zero_width,
+                groupsize,
+                item_ct1,
+                blockvec.get_pointer());
+          });
+    });
+
+}
+
+
+void vecquant8matmul_sycl_old(
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  int groupsize
+) {
+  int batch = vec.size(0);
+  int vec_height = vec.size(1);
+  int height = mat.size(0);
+  int width = mat.size(1);
+  int zero_width = zeros.size(1);
+
+  
+  AT_DISPATCH_FLOATING_TYPES(
+    vec.type(), "vecquant8matmul_sycl_old", ([&] {
+      call_vecquant8matmul_sycl_old<scalar_t>(
+        vec.data<scalar_t>(), mat.data<int>(), mul.data<scalar_t>(),
+        scales.data<scalar_t>(), zeros.data<int>(),
+        batch, vec_height, height, width, zero_width, groupsize
+      );
+    })
+  );
+}
+
+template <typename scalar_t>
+void VecQuant8MatMulKernel_old(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  	int* __restrict__ zeros,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    scalar_t *blockvec) {
+  int b = item_ct1.get_group(0);
+  int h = BLOCKHEIGHT8 * item_ct1.get_group(2);
+  int w = BLOCKWIDTH * item_ct1.get_group(1) + item_ct1.get_local_id(2);
+
+  
+  blockvec[item_ct1.get_local_id(2)] = vec[b * vec_height + item_ct1.get_group(2) * BLOCKWIDTH + item_ct1.get_local_id(2)];
+  
+  item_ct1.barrier(sycl::access::fence_space::local_space);
+
+  scalar_t res = 0;
+  int i = width * h + w;
+  int g_h = h * 4;
+  int k = 0;
+
+  int z_w = w / 4;
+  int z_mod = (w % 4) * 8;
+
+  unsigned int tmp;
+
+  while (k < BLOCKWIDTH) {
+    tmp = as_unsigned(mat[i]);
+
+    int g = (g_h + k) / groupsize;
+    scalar_t scale = scales[g * width + w];
+    scalar_t zero = scale * scalar_t((((as_unsigned(zeros[g * zero_width + z_w]) >> z_mod) & 0xFF) + 1) & 0x0f);
+
+    res += (scale * scalar_t((tmp >> 0) & 0xFF) - zero) * blockvec[k + 0];
+    res += (scale * scalar_t((tmp >> 8) & 0xFF) - zero) * blockvec[k + 1];
+    res += (scale * scalar_t((tmp >> 16) & 0xFF) - zero) * blockvec[k + 2];
+    res += (scale * scalar_t((tmp >> 24) & 0xFF) - zero) * blockvec[k + 3];
+
+    i += width;
+    k += 4;
+  }
+
+  atomicAdd(&mul[b * width + w], res);
+}
+
+
+
+template <typename scalar_t>
+void call_vecquant8matmul_sycl_old(
+    const  scalar_t* __restrict__ vec,
+    const       int* __restrict__ mat,
+           scalar_t* __restrict__ mul,
+    const  scalar_t* __restrict__ scales,
+    const  		int* __restrict__ zeros,
+    const   	int* __restrict__ g_idx,
+    int batch,
+    int vec_height,
+    int height,
+    int width,
+	 int zero_width,
+    int groupsize
+){
+
+
+   using sycl_t = gptq::xpu::SyclTypeTrait<scalar_t>::Type;
+   sycl::range<3> blocks(1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2);
+   sycl::range<3> threads(1, 1, BLOCKWIDTH); //grid
+   auto& q_ct1 = gptq::xpu::gptqGetQueue();
+   q_ct1.submit([&](sycl::handler& cgh) {
+      sycl::local_accessor<sycl_t, 1> blockvec(sycl::range<1>(BLOCKWIDTH), cgh);
+      cgh.parallel_for(
+          sycl::nd_range<3>(blocks * threads, threads),
+          [=](sycl::nd_item<3> item_ct1) {
+            VecQuant8MatMulKernel_old<sycl_t>(
+                (const sycl_t* __restrict__)vec,
+                (const int* __restrict__)mat,
+                (sycl_t* __restrict__)mul,
+                (const sycl_t* __restrict__)scales,
+                (const int* __restrict__)zeros,
+                (const int* __restrict__)g_idx,
+                batch,
+                vec_height,
+                height,
+                width,
+                zero_width,
+                groupsize,
+                item_ct1,
+                blockvec.get_pointer());
+          });
+    });
+
+}
+
+
+void vecquant2matmul_faster_cuda_old(
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  int groupsize,
+  int vec_height
+) {
+  int batch = vec.size(0);
+  int height = mat.size(0);
+  int width = mat.size(1);
+  int zero_width = zeros.size(1);
+
+  //SYCL translation
+  //{
+  //  dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp16});
+  //  dpct::get_in_order_queue().submit(
+  //    [&](sycl::handler &cgh) {
+        /*
+        DPCT1101:27: 'blockwidth2' expression was replaced with a value. Modify the code to use the original expression, provided in comments, if it is correct.
+        */
+  
+  using sycl_t = gptq::xpu::SyclTypeTrait<scalar_t>::Type;
+  sycl::range<3> blocks(1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2);
+  sycl::range<3> threads(1, 1, BLOCKWIDTH); //grid
+  auto& q_ct1 = gptq::xpu::gptqGetQueue();
+  q_ct1.submit([&](sycl::handler& cgh) {
+      sycl::local_accessor<sycl_t, 1> blockvec(sycl::range<1>(BLOCKWIDTH), cgh);
+      sycl::local_accessor<sycl::half2, 2> deq2(sycl::range<2>(16, 16), cgh);
+
+      sycl::half2 * vec_data_ptr_ct0 = (sycl::half2*) vec.data_ptr();
+      const int *__restrict mat_data_ptr_int_ct1 = mat.data_ptr<int>();
+      float *__restrict mul_data_ptr_float_ct2 = mul.data_ptr<float>();
+      const float *__restrict scales_data_ptr_float_ct3 = scales.data_ptr<float>();
+      const int *__restrict zeros_data_ptr_int_ct4 = zeros.data_ptr<int>();
+
+      cgh.parallel_for(
+          sycl::nd_range<3>(blocks * threads, threads),
+          [=](sycl::nd_item<3> item_ct1) {
+          VecQuant2MatMulKernelFaster_old(vec_data_ptr_ct0, 
+                mat_data_ptr_int_ct1, mul_data_ptr_float_ct2,
+                scales_data_ptr_float_ct3, zeros_data_ptr_int_ct4, 
+                batch, vec_height, height, width, zero_width, groupsize, 
+                item_ct1, blockvec.get_pointer(), deq2);
+          });
+      });
+  
+}
+
+void VecQuant2MatMulKernelFaster_old(
+    const  sycl::half2* __restrict__ vec,
+    const    int* __restrict__ mat,
+           float* __restrict__ mul,
+    const  float* __restrict__ scales,
+    const  	 int* __restrict__ zeros,
+	  int batch,
+	  int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    sycl::half2 *blockvec,
+    sycl::local_accessor<sycl::half2, 2> deq2) {
+  
+  const int blockwidth2 = BLOCKWIDTH / 2;
+  int b = item_ct1.get_group(0);
+  int h = BLOCKHEIGHT2 * item_ct1.get_group(2);
+  int w = BLOCKWIDTH * item_ct1.get_group(1) + item_ct1.get_local_id(2);
+
+  
+  if (item_ct1.get_local_id(2) < blockwidth2)
+    blockvec[item_ct1.get_local_id(2)] = vec[b * vec_height + item_ct1.get_group(2) * blockwidth2 + item_ct1.get_local_id(2)];
+
+  
+  int val = item_ct1.get_local_id(2) / 16;
+  int off = item_ct1.get_local_id(2) % 16;
+  for (; val < 16; val += BLOCKWIDTH / 16) {
+    deq2[val][off] = sycl::half2(sycl::vec<int, 1>(val & 0x3).convert<sycl::half, sycl::rounding_mode::rte>()[0], sycl::vec<int, 1>(val >> 2).convert<sycl::half, sycl::rounding_mode::rte>()[0]);
+  }
+
+  int i = width * h + w;
+  int g_h = h * 16;
+  int k = 0;
+
+  int z_w = w / 16;
+  int z_mod = (w % 16) * 2;
+
+  float res = 0;
+  sycl::half2 res2;
+
+  unsigned int tmp;
+
+  
+  item_ct1.barrier(sycl::access::fence_space::local_space);
+
+  while (k < blockwidth2) {
+    int g = (g_h + (k * 2)) / groupsize;
+	float scale_f = scales[g * width + w];
+    sycl::half2 scale = sycl::float2(scale_f).convert<sycl::half, sycl::rounding_mode::rte>();
+    sycl::half2 zero = sycl::float2(-(scale_f * ((((as_unsigned(zeros[g * zero_width + z_w]) >> z_mod) & 0x3) + 1) & 0x0f))).convert<sycl::half, sycl::rounding_mode::rte>();
+
+    std::memset(&res2, 0, sizeof(half2));
+    tmp = as_unsigned(mat[i]);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp >>  0) & 0xf][off], scale, zero), blockvec[k + 0], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp >>  4) & 0xf][off], scale, zero), blockvec[k + 1], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp >>  8) & 0xf][off], scale, zero), blockvec[k + 2], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp >> 12) & 0xf][off], scale, zero), blockvec[k + 3], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp >> 16) & 0xf][off], scale, zero), blockvec[k + 4], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp >> 20) & 0xf][off], scale, zero), blockvec[k + 5], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp >> 24) & 0xf][off], scale, zero), blockvec[k + 6], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp >> 28) & 0xf][off], scale, zero), blockvec[k + 7], res2);
+	i += width;
+    k += 8;
+    res += res2[0] + res2[1];
+  }
+
+  atomicAdd(&mul[b * width + w], res);
+}
+
+void vecquant3matmul_faster_cuda_old(
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  int groupsize,
+  int vec_height
+) {
+  int batch = vec.size(0);
+  int height = mat.size(0);
+  int width = mat.size(1);
+  int zero_width = zeros.size(1);
+
+  //SYCL translation
+  /*{
+    dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp16});
+    dpct::get_in_order_queue().submit(
+      [&](sycl::handler &cgh) {
+        /*
+        DPCT1101:28: 'blockwidth2' expression was replaced with a value. Modify the code to use the original expression, provided in comments, if it is correct.
+        */
+   using sycl_t = gptq::xpu::SyclTypeTrait<scalar_t>::Type;
+   sycl::range<3> blocks(1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2);
+   sycl::range<3> threads(1, 1, BLOCKWIDTH); //grid
+   auto& q_ct1 = gptq::xpu::gptqGetQueue();
+   q_ct1.submit([&](sycl::handler& cgh) {
+        sycl::local_accessor<sycl::half2, 1> blockvec(sycl::range<1>(BLOCKWIDTH), cgh);
+        sycl::local_accessor<sycl::half2, 2> deq2(sycl::range<2>(64, 32), cgh);
+
+        sycl::half2 * vec_data_ptr_ct0 = (sycl::half2*) vec.data_ptr();
+        const int *__restrict mat_data_ptr_int_ct1 = mat.data_ptr<int>();
+        float *__restrict mul_data_ptr_float_ct2 = mul.data_ptr<float>();
+        const float *__restrict scales_data_ptr_float_ct3 = scales.data_ptr<float>();
+        const int *__restrict zeros_data_ptr_int_ct4 = zeros.data_ptr<int>();
+
+        cgh.parallel_for(
+          sycl::nd_range<3>(blocks * threads, threads), 
+          [=](sycl::nd_item<3> item_ct1) {
+            VecQuant3MatMulKernelFaster_old(vec_data_ptr_ct0, mat_data_ptr_int_ct1, 
+            mul_data_ptr_float_ct2, scales_data_ptr_float_ct3, 
+            zeros_data_ptr_int_ct4, batch, vec_height, height, width, zero_width, 
+            groupsize, item_ct1, blockvec.get_pointer(), deq2);
+          });
+      });
+  
+}
+
+void VecQuant3MatMulKernelFaster_old(
+    const  sycl::half2* __restrict__ vec,
+    const    int* __restrict__ mat,
+           float* __restrict__ mul,
+    const  float* __restrict__ scales,
+    const  	 int* __restrict__ zeros,
+	  int batch,
+	  int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    sycl::half2 *blockvec,
+    sycl::local_accessor<sycl::half2, 2> deq2) {
+  const int blockwidth2 = BLOCKWIDTH / 2;
+  int b = item_ct1.get_group(0);
+  int h = BLOCKHEIGHT3 * item_ct1.get_group(2);
+  int w = BLOCKWIDTH * item_ct1.get_group(1) + item_ct1.get_local_id(2);
+
+  
+  if (item_ct1.get_local_id(2) < blockwidth2)
+    blockvec[item_ct1.get_local_id(2)] = vec[b * vec_height + item_ct1.get_group(2) * blockwidth2 + item_ct1.get_local_id(2)];
+
+  
+  int val = item_ct1.get_local_id(2) / 32;
+  int off = item_ct1.get_local_id(2) % 32;
+  for (; val < 64; val += BLOCKWIDTH / 32) {
+    deq2[val][off] = sycl::half2(sycl::vec<int, 1>(val & 0x7).convert<sycl::half, sycl::rounding_mode::rte>()[0], sycl::vec<int, 1>(val >> 3).convert<sycl::half, sycl::rounding_mode::rte>()[0]);
+  }
+
+  int i = width * h + w;
+  int g_h = (h / 3) * 32;
+  int k = 0;
+
+  int z_w = (w / 32) * 3;
+  int z_mod = w % 32;
+  int z_bit;
+
+  if (z_mod != 10){
+    if (z_mod != 21){
+      z_bit = z_mod;
+      if (z_bit > 21){
+        z_bit -= 22;
+        z_bit *= 3;
+        z_bit += 2;
+        z_w += 2;
+      } else if (z_bit > 10){
+        z_bit -= 11;
+        z_bit *= 3;
+        z_bit += 1;
+        z_w += 1;
+      } else {
+        z_bit *= 3;
+      }
+    } else {
+      z_w += 1;
+    }
+  }
+
+  float res = 0;
+  sycl::half2 res2;
+
+  unsigned int tmp1;
+  unsigned int tmp2;
+  unsigned int tmp;
+  unsigned int z_tmp;
+
+  /*
+  DPCT1065:25: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.
+  */
+  item_ct1.barrier();
+
+  while (k < blockwidth2) {
+    int g = (g_h + (k * 2)) / groupsize;
+	float scale_f = scales[g * width + w];
+    sycl::half2 scale = sycl::float2(scale_f).convert<sycl::half, sycl::rounding_mode::rte>();
+    sycl::half2 zero;
+    if (z_mod == 10) {
+      z_tmp = (as_unsigned(zeros[g * zero_width + z_w]) >> 30) | ((as_unsigned(zeros[g * zero_width + (z_w + 1)]) << 2) & 0x4);
+      zero = sycl::float2(-(scale_f * (((z_tmp) + 1) & 0x0f))).convert<sycl::half, sycl::rounding_mode::rte>();
+    } else if (z_mod == 21){
+      z_tmp = (as_unsigned(zeros[g * zero_width + z_w]) >> 31) | ((as_unsigned(zeros[g * zero_width + (z_w + 1)]) << 1) & 0x6);
+      zero = sycl::float2(-(scale_f * (((z_tmp) + 1) & 0x0f))).convert<sycl::half, sycl::rounding_mode::rte>();
+    } else {
+      zero = sycl::float2(-(scale_f * ((((as_unsigned(zeros[g * zero_width + z_w]) >> z_bit) & 0x7) + 1) & 0x0f))).convert<sycl::half, sycl::rounding_mode::rte>();
+    }
+
+    std::memset(&res2, 0, sizeof(half2));
+    tmp1 = as_unsigned(mat[i]);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp1 >>  0) & 0x3f][off], scale, zero), blockvec[k + 0], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp1 >>  6) & 0x3f][off], scale, zero), blockvec[k + 1], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp1 >> 12) & 0x3f][off], scale, zero), blockvec[k + 2], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp1 >> 18) & 0x3f][off], scale, zero), blockvec[k + 3], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp1 >> 24) & 0x3f][off], scale, zero), blockvec[k + 4], res2);
+    i += width;
+    tmp2 = as_unsigned(mat[i]);
+    tmp = (tmp1 >> 30) | ((tmp2 << 2) & 0x3c);
+    res2 = sycl::fma(sycl::fma(deq2[tmp][off], scale, zero), blockvec[k + 5], res2);
+    tmp2 >>= 4;
+    k += 6;
+    res2 = sycl::fma(sycl::fma(deq2[(tmp2 >>  0) & 0x3f][off], scale, zero), blockvec[k + 0], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp2 >>  6) & 0x3f][off], scale, zero), blockvec[k + 1], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp2 >> 12) & 0x3f][off], scale, zero), blockvec[k + 2], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp2 >> 18) & 0x3f][off], scale, zero), blockvec[k + 3], res2);
+    i += width;
+    tmp1 = as_unsigned(mat[i]);
+    tmp = (tmp2 >> 24) | ((tmp1 << 4) & 0x30);
+    res2 = sycl::fma(sycl::fma(deq2[tmp][off], scale, zero), blockvec[k + 4], res2);
+    tmp1 >>= 2;
+    k += 5;
+    res2 = sycl::fma(sycl::fma(deq2[(tmp1 >>  0) & 0x3f][off], scale, zero), blockvec[k + 0], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp1 >>  6) & 0x3f][off], scale, zero), blockvec[k + 1], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp1 >> 12) & 0x3f][off], scale, zero), blockvec[k + 2], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp1 >> 18) & 0x3f][off], scale, zero), blockvec[k + 3], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp1 >> 24) & 0x3f][off], scale, zero), blockvec[k + 4], res2);
+    i += width;
+    k += 5;
+    res += res2[0] + res2[1];
+  }
+
+  dpct::atomic_fetch_add<sycl::access::address_space::generic_space>(&mul[b * width + w], res);
+}
+
+void vecquant4matmul_faster_cuda_old(
+  torch::Tensor vec,
+  torch::Tensor mat,
+  torch::Tensor mul,
+  torch::Tensor scales,
+  torch::Tensor zeros,
+  int groupsize,
+  int vec_height
+) {
+  int batch = vec.size(0);
+  int height = mat.size(0);
+  int width = mat.size(1);
+  int zero_width = zeros.size(1);
+
+  //SYCL translation
+  /*
+  {
+    dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp16});
+    dpct::get_in_order_queue().submit(
+      [&](sycl::handler &cgh) {
+        /*
+        DPCT1101:29: 'blockwidth2' expression was replaced with a value. Modify the code to use the original expression, provided in comments, if it is correct.
+        */
+   using sycl_t = gptq::xpu::SyclTypeTrait<scalar_t>::Type;
+   sycl::range<3> blocks(1, (width + BLOCKWIDTH - 1) / BLOCKWIDTH, (height + BLOCKHEIGHT2 - 1) / BLOCKHEIGHT2);
+   sycl::range<3> threads(1, 1, BLOCKWIDTH); //grid
+   auto& q_ct1 = gptq::xpu::gptqGetQueue();
+   q_ct1.submit([&](sycl::handler& cgh) {
+        sycl::local_accessor<sycl::half2, 1> blockvec(sycl::range<1>(BLOCKWIDTH), cgh);
+        sycl::local_accessor<sycl::half2, 2> deq2(sycl::range<2>(256, 8), cgh);
+
+        sycl::half2 * vec_data_ptr_ct0 = (sycl::half2*) vec.data_ptr();
+        const int *__restrict mat_data_ptr_int_ct1 = mat.data_ptr<int>();
+        float *__restrict mul_data_ptr_float_ct2 = mul.data_ptr<float>();
+        const float *__restrict scales_data_ptr_float_ct3 = scales.data_ptr<float>();
+        const int *__restrict zeros_data_ptr_int_ct4 = zeros.data_ptr<int>();
+
+        cgh.parallel_for(
+          sycl::nd_range<3>(blocks * threads, threads), 
+          [=](sycl::nd_item<3> item_ct1) {
+            VecQuant4MatMulKernelFaster_old(vec_data_ptr_ct0, mat_data_ptr_int_ct1, 
+            mul_data_ptr_float_ct2, scales_data_ptr_float_ct3, zeros_data_ptr_int_ct4, 
+            batch, vec_height, height, width, zero_width, 
+            groupsize, item_ct1, blockvec.get_pointer(), deq2);
+          });
+      });
+  
+}
+
+void VecQuant4MatMulKernelFaster_old(
+    const  sycl::half2* __restrict__ vec,
+    const    int* __restrict__ mat,
+           float* __restrict__ mul,
+    const  float* __restrict__ scales,
+    const  	 int* __restrict__ zeros,
+	 int batch,
+	 int vec_height,
+    int height,
+    int width,
+    int zero_width,
+    int groupsize,
+    const sycl::nd_item<3> &item_ct1,
+    sycl::half2 *blockvec,
+    sycl::local_accessor<sycl::half2, 2> deq2) {
+    
+  const int blockwidth2 = BLOCKWIDTH / 2;
+  int b = item_ct1.get_group(0);
+  int h = BLOCKHEIGHT4 * item_ct1.get_group(2);
+  int w = BLOCKWIDTH * item_ct1.get_group(1) + item_ct1.get_local_id(2);
+
+  
+  if (item_ct1.get_local_id(2) < blockwidth2)
+    blockvec[item_ct1.get_local_id(2)] = vec[b * vec_height + item_ct1.get_group(2) * blockwidth2 + item_ct1.get_local_id(2)];
+
+  
+  int val = item_ct1.get_local_id(2) / 8;
+  int off = item_ct1.get_local_id(2) % 8;
+  for (; val < 256; val += BLOCKWIDTH / 8) {
+    deq2[val][off] = sycl::half2(sycl::vec<int, 1>(val & 0xF).convert<sycl::half, sycl::rounding_mode::rte>()[0], sycl::vec<int, 1>(val >> 4).convert<sycl::half, sycl::rounding_mode::rte>()[0]);
+  }
+
+  int i = width * h + w;
+  int g_h = h * 8;
+  int k = 0;
+
+  int z_w = w / 8;
+  int z_mod = (w % 8) * 4;
+
+  float res = 0;
+  sycl::half2 res2;
+
+  unsigned int tmp;
+
+  
+  item_ct1.barrier(sycl::access::fence_space::local_space);
+
+  while (k < blockwidth2) {
+    int g = (g_h + (k * 2)) / groupsize;
+	float scale_f = scales[g * width + w];
+
+    sycl::half2 scale = sycl::float2(scale_f).convert<sycl::half, sycl::rounding_mode::rte>();
+    sycl::half2 zero = sycl::float2(-(scale_f * ((((as_unsigned(zeros[g * zero_width + z_w]) >> z_mod) & 0xF) + 1) & 0x0f))).convert<sycl::half, sycl::rounding_mode::rte>();
+
+    //std::memset(&res2, 0, sizeof(half2));
+
+    //res2 = __float2half2_rn((float)0.);
+
+    std::memset(&res2, 0, sizeof(half2));
+    tmp = as_unsigned(mat[i]);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp >>  0) & 0xff][off], scale, zero), blockvec[k + 0], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp >>  8) & 0xff][off], scale, zero), blockvec[k + 1], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp >> 16) & 0xff][off], scale, zero), blockvec[k + 2], res2);
+    res2 = sycl::fma(sycl::fma(deq2[(tmp >> 24) & 0xff][off], scale, zero), blockvec[k + 3], res2);
+	i += width;
+    k += 4;
+
+    res += res2[0] + res2[1];
+
+  }
+
+  atomicAdd(&mul[b * width + w], res);
+}

--- a/autogptq_extension/sycl/sycl_utils.cpp
+++ b/autogptq_extension/sycl/sycl_utils.cpp
@@ -1,0 +1,34 @@
+#include "sycl_utils.h"
+#include <sycl/ext/intel/math.hpp>
+
+sycl::half sycl_half_mul(sycl::half a, sycl::half b) {
+  return sycl::ext::intel::math::hmul(a, b);
+}
+sycl::half sycl_half_add(sycl::half a, sycl::half b) {
+  return sycl::ext::intel::math::hadd(a, b);
+}
+sycl::half sycl_half_sub(sycl::half a, sycl::half b) {
+  return sycl::ext::intel::math::hsub(a, b);
+}
+sycl::half sycl_half_fma(sycl::half a, sycl::half b, sycl::half c) {
+  return sycl::ext::intel::math::hfma(a, b, c);
+}
+
+sycl::half2 sycl_half_mul2(sycl::half2 a, sycl::half2 b) {
+  return sycl::ext::intel::math::hmul2(a, b);
+}
+sycl::half2 sycl_half_add2(sycl::half2 a, sycl::half2 b) {
+  return sycl::ext::intel::math::hadd2(a, b);
+}
+sycl::half2 sycl_half_sub2(sycl::half2 a, sycl::half2 b) {
+  return sycl::ext::intel::math::hsub2(a, b);
+}
+
+sycl::half2 sycl_half_fma2(sycl::half2 a, sycl::half2 b, sycl::half2 c) {
+  return sycl::ext::intel::math::hfma2(a, b, c);
+}
+
+int get_max_shared_memory_per_block_device_attribute(int device_id) {
+  const sycl::device& device = gptq::xpu::gptqGetQueue().get_device();
+  return device.get_info<sycl::info::device::local_mem_size>();
+}

--- a/autogptq_extension/sycl/sycl_utils.h
+++ b/autogptq_extension/sycl/sycl_utils.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <sycl/sycl.hpp>
+#include <memory>
+#include <ipex.h>
+#include <ATen/ATen.h>
+
+namespace gptq {
+namespace xpu {
+
+static inline sycl::queue& gptqGetQueue() {
+  auto device_type = c10::DeviceType::XPU;
+  c10::impl::VirtualGuardImpl impl(device_type);
+  c10::Stream c10_stream = impl.getStream(c10::Device(device_type));
+  auto& queue = ::xpu::get_queue_from_stream(c10_stream);
+  return queue;
+}
+template <typename T>
+struct SyclTypeTrait{
+  using Type = T;
+};
+
+template <>
+struct SyclTypeTrait<c10::Half>{
+  using Type = sycl::half;
+};
+
+template <>
+struct SyclTypeTrait<c10::BFloat16>{
+  using Type = sycl::ext::oneapi::bfloat16;
+};
+
+
+} // namespace xpu
+
+} // namespace gptq
+
+SYCL_EXTERNAL sycl::half sycl_half_mul(sycl::half a, sycl::half b);
+SYCL_EXTERNAL sycl::half sycl_half_add(sycl::half a, sycl::half b);
+SYCL_EXTERNAL sycl::half sycl_half_sub(sycl::half a, sycl::half b);
+SYCL_EXTERNAL sycl::half sycl_half_fma(sycl::half a, sycl::half b, sycl::half c);
+
+SYCL_EXTERNAL sycl::half2 sycl_half_mul2(sycl::half2 a, sycl::half2 b);
+SYCL_EXTERNAL sycl::half2 sycl_half_add2(sycl::half2 a, sycl::half2 b);
+SYCL_EXTERNAL sycl::half2 sycl_half_sub2(sycl::half2 a, sycl::half2 b);
+SYCL_EXTERNAL sycl::half2 sycl_half_fma2(sycl::half2 a, sycl::half2 b, sycl::half2 c);
+
+int get_max_shared_memory_per_block_device_attribute(int device_id);


### PR DESCRIPTION
Hello  @PanQiWei . @qwopqwop200 , @fxmarty .Greetings from Intel.  Thanks for creating AutoGPTQ.

Considering adoption of more SYCL runtime across different vendors and specifically for Intel accelerators, this is an effort to upstream the cuda kernels for (gemm/non gemm quants) to SYCL runtime . This is an approach taken to further extend Intel accelerator support as well as provide an alternative compiler runtime for non cuda specific devices.  

The proposal is to extend SYCL runtime through DPCT toolchain and to support a standard runtime for different vendors.  
Since the idea is to provide better sycl compiler characterization, this PR would help enable the framework for a wide range of accelerators working on SYCL runtime.S
An initial kernel prototype is added, and further extension kernels will be ported to support SYCL backend in next couple of days. (Draft mode).
An extended idea: (if community is interested)  SYCL maintenance will be extended by myself (team) and external contributors and depending upon support received we plan to integrate nv/amd and other vendor support for SYCL runtime for AutoGPTQ.


