### PR TITLE
[PERFORMANCE] Fix Packing thread regression in code

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -187,23 +187,6 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
         if self.quantize_config.quant_method in QUANTIZE_BLACK_LIST:
             raise ValueError(f"Unsupported quantization operation for quant method: {self.quantize_config.quant_method}")
 
-        # alert users to limit threads so packing performance does not regress by up to ~100x
-        thread_warning = """If you have not already done so, please inject the following code at the very top of your 
-quantization script so the packing stage is optimized for speed. Using too many cores may reduce packing performance.
-----
-import os
-import math
-max_threads = str(min(8, os.cpu_count()))
-os.environ['OMP_NUM_THREADS'] = max_threads
-os.environ['OPENBLAS_NUM_THREADS'] = max_threads
-os.environ['MKL_NUM_THREADS'] = max_threads
-os.environ['VECLIB_MAXIMUM_THREADS'] = max_threads
-os.environ['NUMEXPR_NUM_THREADS'] = max_threads
-os.environ['NUMEXPR_MAX_THREADS'] = max_threads
-----
-"""
-        logger.warning(thread_warning)
-
         if use_triton and not TRITON_AVAILABLE:
             logger.warning("triton is not installed, reset use_triton to False")
             use_triton = False

--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ requirements = [
     "transformers>=4.31.0",
     "peft>=0.5.0",
     "tqdm",
+    "threadpoolctl",
 ]
 
 extras_require = {

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
+addopts=-s -v
 log_cli=true

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -1,14 +1,4 @@
 import os
-import math
-
-max_threads = str(min(8, os.cpu_count()))
-os.environ['OMP_NUM_THREADS'] = max_threads
-os.environ['OPENBLAS_NUM_THREADS'] = max_threads
-os.environ['MKL_NUM_THREADS'] = max_threads
-os.environ['VECLIB_MAXIMUM_THREADS'] = max_threads
-os.environ['NUMEXPR_NUM_THREADS'] = max_threads
-os.environ['NUMEXPR_MAX_THREADS'] = max_threads
-
 import tempfile
 import unittest
 


### PR DESCRIPTION
Reason for PR:

* Packing has unfixed thread regression on env with lots of cpu cores. The more cores you have, the slower your packing time becomes. Non-linear regression.
* Previous fix was simple warning on injecting env vars.  https://github.com/AutoGPTQ/AutoGPTQ/pull/628
* PR fixes this issue, not the core cause, by limiting packing() context to use 1 thread. https://github.com/AutoGPTQ/AutoGPTQ/issues/439

However, this will need a new pkg depend: https://github.com/joblib/threadpoolctl 

>Python helpers to limit the number of threads used in native libraries that handle their own internal threadpool (BLAS and OpenMP implementations)

ref: https://github.com/AutoGPTQ/AutoGPTQ/pull/640#discussion_r1566931521

Tests Passed:

* [x] test_quantization
* [x] test_serialization