### PR TITLE
Extend support for Phi-3 models

### DIFF
--- a/auto_gptq/modeling/__init__.py
+++ b/auto_gptq/modeling/__init__.py
@@ -19,6 +19,7 @@ from .moss import MOSSGPTQForCausalLM
 from .mpt import MPTGPTQForCausalLM
 from .opt import OPTGPTQForCausalLM
 from .phi import PhiGPTQForCausalLM
+from .phi3 import Phi3GPTQForCausalLM
 from .qwen import QwenGPTQForCausalLM
 from .qwen2 import Qwen2GPTQForCausalLM
 from .rw import RWGPTQForCausalLM

--- a/auto_gptq/modeling/_const.py
+++ b/auto_gptq/modeling/_const.py
@@ -44,6 +44,8 @@ if compare_transformers_version("v4.38.0", op="ge"):
     SUPPORTED_MODELS.append("gemma")
 if compare_transformers_version("v4.39.0.dev0", op="ge"):
     SUPPORTED_MODELS.append("starcoder2")
+if compare_transformers_version("v4.40.0.dev", op="ge"):
+    SUPPORTED_MODELS.append("phi3")
 
 EXLLAMA_DEFAULT_MAX_INPUT_LENGTH = 2048
 

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -22,6 +22,7 @@ from .moss import MOSSGPTQForCausalLM
 from .mpt import MPTGPTQForCausalLM
 from .opt import OPTGPTQForCausalLM
 from .phi import PhiGPTQForCausalLM
+from .phi3 import Phi3GPTQForCausalLM
 from .qwen import QwenGPTQForCausalLM
 from .qwen2 import Qwen2GPTQForCausalLM
 from .rw import RWGPTQForCausalLM
@@ -59,6 +60,7 @@ GPTQ_CAUSAL_LM_MODEL_MAP = {
     "longllama": LongLlamaGPTQForCausalLM,
     "gemma": GemmaGPTQForCausalLM,
     "phi": PhiGPTQForCausalLM,
+    "phi3": Phi3GPTQForCausalLM,
     "mpt": MPTGPTQForCausalLM,
 }
 

--- a/auto_gptq/modeling/phi3.py
+++ b/auto_gptq/modeling/phi3.py
@@ -1,0 +1,16 @@
+from ._base import BaseGPTQForCausalLM
+
+
+class Phi3GPTQForCausalLM(BaseGPTQForCausalLM):
+    layer_type = "Phi3DecoderLayer"
+    layers_block_name = "model.layers"
+    outside_layer_modules = ["model.embed_tokens", "embed_dropout", "model.norm"]
+    inside_layer_modules = [
+        ["self_attn.qkv_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.gate_up_proj"],
+        ["mlp.down_proj"],
+    ]
+
+
+__all__ = ["Phi3GPTQForCausalLM"]


### PR DESCRIPTION
### Description
- Extend support for Microsoft's [Phi-3 models](https://huggingface.co/collections/microsoft/phi-3-6626e15e9585a200d2d761e3)

### Technical Details
- Very Straightforward implementation following adding custom models guide in the README
- My only concern is Phi 3 seems to have fused the QKV and MLP modules. I looked into the code and it seems like it's actually not a big deal to just directly quantize them since, for example, `qkv_proj` is just a `nn.Linear`. However, I could be wrong, and would be great if someone wants to nudge me in the right direction.

### Tests
- I tested by making GPTQ quants on the 2 Phi-3-mini instruct models (4k and 128k context length). Both work ok with HF's text generation pipeline. 
    - Used wikitext for calibration dataset, 4096 seq length and 500 samples each.
- I am following along vLLM team's discussion (there are some minor issues they are fixing) for Phi-3 support, but I think this should work ok once their sliding window assertion problem is fixed.

### Side Note
- Hi AutoGPTQ team, this is my first time contributing to AutoGPTQ library. Please feel free to guide me towards the right direction if needed. I couldn't find a contributing markdown file for guidance so just making this formatting as nice as possible.