### PR TITLE
Support QBits kernel for CPU device

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ AutoGPTQ is available on Linux and Windows only. You can install the latest stab
 
 AutoGPTQ can be installed with the Triton dependency with `pip install auto-gptq[triton] --no-build-isolation` in order to be able to use the Triton backend (currently only supports linux, no 3-bits quantization).
 
+AutoGPTQ also support CPU device now and requires the installation of QBits nernel dependency with `pip install intel-extension-for-transformers`. Or you can install auto-gptq with `pip install auto-gptq[qbits]`. 
+
 For older AutoGPTQ, please refer to [the previous releases installation table](docs/INSTALLATION.md).
 
 On NVIDIA systems, AutoGPTQ does not support [Maxwell or lower](https://qiita.com/uyuni/items/733a93b975b524f89f46) GPUs.

--- a/README_zh.md
+++ b/README_zh.md
@@ -86,6 +86,14 @@ pip uninstall autogptq_cuda -y
 pip install auto-gptq[triton]
 ```
 
+#### 支持CPU加速
+AutoGPTQ支持在CPU设备上的加速，使用以下命令安装QBits kernel：
+> 警告：目前 QBits 仅支持4-bit 和8-bit 数值类型的量化
+
+```shell
+pip install auto-gptq[qbits]
+```
+
 ### 从源码安装
 <details>
 <summary>点击以查看详情</summary>

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -111,6 +111,7 @@ class AutoGPTQForCausalLM:
         disable_exllamav2: bool = False,
         use_marlin: bool = False,
         use_tritonv2: bool = False,
+        use_qbits: bool = False,
         **kwargs,
     ) -> BaseGPTQForCausalLM:
         # If disable_exllamav2 is True, we want to fall back on the exllama kernel and not the cuda/cuda_old ones.
@@ -161,6 +162,7 @@ class AutoGPTQForCausalLM:
             disable_exllamav2=disable_exllamav2,
             use_marlin=use_marlin,
             use_tritonv2=use_tritonv2,
+            use_qbits=use_qbits,
             **keywords,
         )
 

--- a/auto_gptq/nn_modules/fused_gptj_attn.py
+++ b/auto_gptq/nn_modules/fused_gptj_attn.py
@@ -237,6 +237,7 @@ class FusedGPTJAttentionForQuantizedModel(FusedBaseAttentionModule):
         bits: int = 4,
         disable_exllama=True,
         disable_exllamav2=False,
+        use_qbits=False,
         **kwargs,
     ):
         config = model.config
@@ -247,6 +248,7 @@ class FusedGPTJAttentionForQuantizedModel(FusedBaseAttentionModule):
             bits=bits,
             disable_exllama=disable_exllama,
             disable_exllamav2=disable_exllamav2,
+            use_qbits=use_qbits,
         )
 
         for name, m in model.named_modules():

--- a/auto_gptq/nn_modules/fused_llama_attn.py
+++ b/auto_gptq/nn_modules/fused_llama_attn.py
@@ -146,6 +146,7 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
         bits: int = 4,
         disable_exllama=True,
         disable_exllamav2=False,
+        use_qbits=False,
         **kwargs,
     ):
         """
@@ -158,6 +159,7 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
             bits=bits,
             disable_exllama=disable_exllama,
             disable_exllamav2=disable_exllamav2,
+            use_qbits=use_qbits,
         )
 
         for name, m in model.named_modules():

--- a/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
@@ -237,6 +237,7 @@ def unpack_qzeros(qzeros):
 def dequantize_weight(layer):
     qweight, qzeros, scales = layer.qweight, layer.qzeros, layer.scales
     unpacked_qweight, unpacked_qzeros = unpack_4bit_to_32bit_signed(qweight, qzeros)
+    unpacked_qzeros = torch.clamp(unpacked_qzeros, min=0, max=15)
     group_size = unpacked_qweight.shape[0] // scales.shape[0]
     scales = scales.repeat_interleave(group_size, dim=0)
     unpacked_qzeros = unpacked_qzeros.repeat_interleave(group_size, dim=0)

--- a/auto_gptq/nn_modules/qlinear/qlinear_qbits.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_qbits.py
@@ -1,0 +1,320 @@
+import math
+
+import numpy as np
+import torch
+import torch.nn as nn
+import transformers
+from ...utils.import_utils import QBITS_AVAILABLE
+from logging import getLogger
+
+
+logger = getLogger(__name__)
+
+if QBITS_AVAILABLE:
+    from intel_extension_for_transformers import qbits  # with QBits kernels ()
+
+BITS_DTYPE_MAPPING = {
+    4: "int4_clip",
+    8: "int8",
+}
+
+
+def convert_dtype_torch2str(dtype):
+    if dtype == torch.int8:
+        return "int8"
+    elif dtype == torch.float:
+        return "fp32"
+    elif dtype == torch.float16:
+        return "fp16"
+    elif dtype == torch.bfloat16:
+        return "bf16"
+    elif isinstance(dtype, str) and dtype in ["int8", "fp32", "fp16", "bf16"]:
+        return dtype
+    else:
+        assert False, "Unsupported pytorch dtype {} to str dtype".format(dtype)
+
+
+class QuantLinear(nn.Module):
+    QUANT_TYPE = "qbits"
+
+    def __init__(
+        self,
+        bits,
+        group_size,
+        infeatures,
+        outfeatures,
+        bias,
+        kernel_switch_threshold=128,
+        trainable=False,
+        weight_dtype=torch.bfloat16,
+        **kwargs,
+    ):
+        super().__init__()
+
+        if bits not in [4, 8]:
+            raise NotImplementedError("Only 4,8 bits are supported for QBits.")
+
+        self.infeatures = infeatures
+        self.outfeatures = outfeatures
+        self.bits = bits
+        self.group_size = group_size if group_size != -1 else infeatures
+        self.maxq = 2**self.bits - 1
+        self.weight_dtype = weight_dtype
+        self.asym = True
+
+        self.register_buffer(
+            "qweight",
+            torch.zeros((infeatures // 32 * self.bits, outfeatures), dtype=torch.int32),
+        )
+        self.register_buffer(
+            "qzeros",
+            torch.zeros(
+                (
+                    math.ceil(infeatures / self.group_size),
+                    outfeatures // 32 * self.bits,
+                ),
+                dtype=torch.int32,
+            ),
+        )
+        self.register_buffer(
+            "scales",
+            torch.zeros(
+                (math.ceil(infeatures / self.group_size), outfeatures),
+                dtype=weight_dtype,
+            ),
+        )
+        self.register_buffer(
+            "g_idx",
+            torch.tensor([i // self.group_size for i in range(infeatures)], dtype=torch.int32),
+        )
+        if bias:
+            self.register_buffer("bias", torch.zeros((outfeatures), dtype=weight_dtype))
+        else:
+            self.bias = None
+
+        self.kernel_switch_threshold = kernel_switch_threshold
+
+        self.trainable = trainable
+
+    def post_init(self):
+        assert self.qweight.device.type == "cpu"
+        if self.bias is not None:
+            self.bias = self.bias.to(dtype=torch.float32)
+
+        default_idx = torch.tensor([i // self.group_size for i in range(self.infeatures)], dtype=torch.int32)
+        is_desc_act = not torch.all(torch.eq(default_idx, self.g_idx))
+        # intweight: k x n, zeros: k / group_size x n
+        intweight, zeros = unpack_to_8bit_signed(self.qweight, self.qzeros, self.bits,
+                                                 self.g_idx if is_desc_act else None)
+        if zeros is None:
+            zeros = torch.empty(0, dtype=torch.int8)
+            self.asym = False
+        else:
+            # change it to int8 with offset 128
+            if self.bits == 8:
+                zeros = (zeros.to(torch.int32) - (2 ** (self.bits - 1))).to(torch.int8)
+            else:
+                zeros -= (2**(self.bits - 1))
+                zeros.bitwise_left_shift_(8 - self.bits)
+
+        if not self.asym:
+            intweight -= (2**(self.bits - 1))
+        intweight = intweight.to(torch.uint8 if self.asym else torch.int8)
+        # due to asym return torch.uint8 but backend request int8,
+        # change it to int8 with offset 128
+        if self.asym:
+            intweight = (intweight.to(torch.int32) - (2 ** (self.bits - 1))).to(torch.int8)
+
+        if self.bits == 4:
+            intweight.bitwise_left_shift_((8 - self.bits))
+
+        scales = self.scales if self.bits == 8 else self.scales / (2 ** (8 - self.bits))
+
+        if not is_desc_act:
+            g_idx = torch.empty(0, dtype=torch.int32)
+        else:
+            g_idx = self.g_idx
+
+        self.qweight = qbits.repack_quantized_weight(intweight.contiguous(), scales.float(), zeros, g_idx,
+                                                     BITS_DTYPE_MAPPING[self.bits],  # weight_dtype
+                                                     "fp32",  # scale_dtype
+                                                     convert_dtype_torch2str(self.scales.dtype),  # compute_dtype
+                                                     self.asym,
+                                                     self.group_size)
+
+    def pack(self, linear, scales, zeros, g_idx=None):
+        W = linear.weight.data.clone()
+        if isinstance(linear, nn.Conv2d):
+            W = W.flatten(1)
+        if isinstance(linear, transformers.pytorch_utils.Conv1D):
+            W = W.t()
+
+        self.g_idx = g_idx.clone() if g_idx is not None else self.g_idx
+
+        scales = scales.t().contiguous()
+        zeros = zeros.t().contiguous()
+        scale_zeros = zeros * scales
+        self.scales = scales.clone().to(dtype=linear.weight.dtype)
+        if linear.bias is not None:
+            self.bias = linear.bias.clone().to(dtype=linear.weight.dtype)
+
+        intweight = []
+        for idx in range(self.infeatures):
+            intweight.append(
+                torch.round(
+                    (W[:, idx] + scale_zeros[self.g_idx[idx]]) / self.scales[self.g_idx[idx]]).to(torch.int)[:, None])
+        intweight = torch.cat(intweight, dim=1)
+        intweight = intweight.t().contiguous()
+        intweight = intweight.numpy().astype(np.uint32)
+
+        i = 0
+        row = 0
+        qweight = np.zeros((intweight.shape[0] // 32 * self.bits, intweight.shape[1]), dtype=np.uint32)
+        while row < qweight.shape[0]:
+            if self.bits in [2, 4, 8]:
+                for j in range(i, i + (32 // self.bits)):
+                    qweight[row] |= intweight[j] << (self.bits * (j - i))
+                i += 32 // self.bits
+                row += 1
+            elif self.bits == 3:
+                for j in range(i, i + 10):
+                    qweight[row] |= intweight[j] << (3 * (j - i))
+                i += 10
+                qweight[row] |= intweight[i] << 30
+                row += 1
+                qweight[row] |= (intweight[i] >> 2) & 1
+                i += 1
+                for j in range(i, i + 10):
+                    qweight[row] |= intweight[j] << (3 * (j - i) + 1)
+                i += 10
+                qweight[row] |= intweight[i] << 31
+                row += 1
+                qweight[row] |= (intweight[i] >> 1) & 0x3
+                i += 1
+                for j in range(i, i + 10):
+                    qweight[row] |= intweight[j] << (3 * (j - i) + 2)
+                i += 10
+                row += 1
+            else:
+                raise NotImplementedError("Only 2,3,4,8 bits are supported.")
+
+        qweight = qweight.astype(np.int32)
+        self.qweight = torch.from_numpy(qweight)
+
+        zeros -= 1
+        zeros = zeros.numpy().astype(np.uint32)
+        qzeros = np.zeros((zeros.shape[0], zeros.shape[1] // 32 * self.bits), dtype=np.uint32)
+        i = 0
+        col = 0
+        while col < qzeros.shape[1]:
+            if self.bits in [2, 4, 8]:
+                for j in range(i, i + (32 // self.bits)):
+                    qzeros[:, col] |= zeros[:, j] << (self.bits * (j - i))
+                i += 32 // self.bits
+                col += 1
+            elif self.bits == 3:
+                for j in range(i, i + 10):
+                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i))
+                i += 10
+                qzeros[:, col] |= zeros[:, i] << 30
+                col += 1
+                qzeros[:, col] |= (zeros[:, i] >> 2) & 1
+                i += 1
+                for j in range(i, i + 10):
+                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 1)
+                i += 10
+                qzeros[:, col] |= zeros[:, i] << 31
+                col += 1
+                qzeros[:, col] |= (zeros[:, i] >> 1) & 0x3
+                i += 1
+                for j in range(i, i + 10):
+                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 2)
+                i += 10
+                col += 1
+            else:
+                raise NotImplementedError("Only 2,3,4,8 bits are supported.")
+
+        qzeros = qzeros.astype(np.int32)
+        self.qzeros = torch.from_numpy(qzeros)
+
+    def forward(self, x: torch.Tensor):
+        input_dtype = x.dtype
+        out_shape = x.shape[:-1] + (self.outfeatures,)
+        x = x.view(-1, x.shape[-1])  # convert xd to 2d
+        out_2d_shape = x.shape[:-1] + (self.outfeatures,)
+
+        outputs = torch.zeros(out_2d_shape, device=x.device, dtype=input_dtype)
+        bias = self.bias if self.bias is not None else torch.empty(
+            0, dtype=input_dtype)
+
+        qbits.woq_linear(x, self.qweight, bias, outputs,
+                         convert_dtype_torch2str(input_dtype),  # compute_dtype
+                         BITS_DTYPE_MAPPING[self.bits],  # weight_dtype
+                         "fp32",  # scale_dtype
+                         self.asym)
+        return outputs.view(out_shape)
+
+
+@torch.no_grad()
+def unpack_to_8bit_signed(qweight, qzeros, bits, g_idx=None):
+    wf = torch.tensor(list(range(0, 32, bits)), dtype=torch.int32).unsqueeze(0)
+    zeros = None
+    if not torch.all(torch.eq(qzeros, 2004318071 if bits == 4 else 0b01111111011111110111111101111111)):
+        zp_shape = list(qzeros.shape)
+        zp_shape[1] = zp_shape[1] * (32 // bits)
+
+        zeros = torch.bitwise_right_shift(
+            torch.unsqueeze(qzeros, 2).expand(-1, -1, 32 // bits), wf.unsqueeze(0)
+        ).to(torch.int16 if bits == 8 else torch.int8)
+        torch.bitwise_and(zeros, (2**bits) - 1, out=zeros)
+        if bits == 8:
+            zeros = zeros.to(torch.uint8)
+        zeros = zeros + 1
+        try:
+            zeros = zeros.reshape(zp_shape)
+        except:
+            # zeros and scales have different iteam numbers.
+            # remove 1 (due to 0 + 1 in line 252)
+            zeros = zeros[zeros != 1]
+            zeros = zeros.reshape(zp_shape)
+
+    weight = torch.bitwise_right_shift(
+        torch.unsqueeze(qweight, 1).expand(-1, 32 // bits, -1), wf.unsqueeze(-1)
+    ).to(torch.int16 if bits == 8 else torch.int8)
+    weight.bitwise_and_((2**bits) - 1)
+    weight = weight.view(-1, weight.shape[-1])
+
+    if g_idx is not None:
+        group_size = weight.shape[0] // qzeros.shape[0]
+        weight2 = weight.clone()
+        group_dict = {}
+        for i in range(len(g_idx)):
+            group_idx = g_idx[i].item()
+            if group_idx not in group_dict:
+                target_idx = group_idx * group_size
+                group_dict[group_idx] = 0
+            else:
+                group_dict[group_idx] = group_dict[group_idx] + 1
+                target_idx = group_idx * group_size + group_dict[group_idx]
+            weight2[target_idx] = weight[i]
+        weight = weight2
+
+    return weight, zeros
+
+
+# Copied from qlinear_marlin.py
+@torch.no_grad()
+def dequantize_weight(qweight, qzeros, scales, bits):
+    unpacked_qweight, unpacked_qzeros = unpack_to_8bit_signed(qweight, qzeros, bits)
+    group_size = unpacked_qweight.shape[0] // scales.shape[0]
+    scales = scales.repeat_interleave(group_size, dim=0)
+    if unpacked_qzeros is not None:
+        unpacked_qzeros = unpacked_qzeros.repeat_interleave(group_size, dim=0)
+    else:
+        unpacked_qzeros = torch.full_like(scales, 8 if bits == 4 else 128, dtype=torch.int32)
+    unpacked_qweight = (unpacked_qweight - unpacked_qzeros) * scales
+
+    return unpacked_qweight, unpacked_qzeros
+
+
+__all__ = ["QuantLinear"]

--- a/auto_gptq/quantization/gptq.py
+++ b/auto_gptq/quantization/gptq.py
@@ -166,7 +166,8 @@ class GPTQ:
                 logger.debug(torch.sum((self.layer(self.inp1) - self.out1) ** 2))
                 logger.debug(torch.sum(Losses))
 
-        torch.cuda.synchronize()
+        if self.dev != torch.device("cpu"):
+            torch.cuda.synchronize()
         logger.info(f"duration: {(time.time() - tick)}")
         logger.info(f"avg loss: {torch.sum(Losses).item() / self.nsamples}")
 
@@ -200,7 +201,8 @@ class GPTQ:
         self.H = None
         self.Losses = None
         self.Trace = None
-        torch.cuda.empty_cache()
+        if self.dev != torch.device("cpu"):
+            torch.cuda.empty_cache()
 
 
 __all__ = ["GPTQ"]

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,8 +2,9 @@
 
 On Linux and Windows, AutoGPTQ can be installed through pre-built wheels for specific PyTorch versions:
 
-| AutoGPTQ version | CUDA/ROCm version | Installation                                                                                               | Built against PyTorch |
+| AutoGPTQ version | CUDA/ROCm/ITREX version | Installation                                                                                               | Built against PyTorch |
 |------------------|-------------------|------------------------------------------------------------------------------------------------------------|-----------------------|
+| latest    | ITREX 1.4.1         | `pip install auto-gptq [qbits]`          | 2.2.1+cpu           |
 | latest (0.7.1)   | CUDA 11.8         | `pip install auto-gptq --extra-index-url https://huggingface.github.io/autogptq-index/whl/cu118/`          | 2.2.1+cu118           |
 | latest (0.7.1)   | CUDA 12.1         | `pip install auto-gptq`                                                                                    | 2.2.1+cu121           |
 | latest (0.7.1)   | ROCm 5.7          | `pip install auto-gptq --extra-index-url https://huggingface.github.io/autogptq-index/whl/rocm571/`        | 2.2.1+rocm5.7         |

--- a/docs/tutorial/02-Advanced-Model-Loading-and-Best-Practice.md
+++ b/docs/tutorial/02-Advanced-Model-Loading-and-Best-Practice.md
@@ -60,6 +60,9 @@ You can provide a string to this argument to use pre-set model loading strategie
 
 In the simplest way, you can set `device_map='auto'` and let 🤗 Accelerate handle the device map computation. For more details of this argument, you can reference to [this document](https://huggingface.co/docs/accelerate/main/en/usage_guides/big_modeling#designing-a-device-map).
 
+### Load model with QBits kernel for CPU device
+In CPU only device, AutoGPTQ will load model with QBits linear automatically. Or you can use the argument `use_qbits` in `.from_quantized`.
+
 ## Best Practice
 
 ### At Quantization

--- a/examples/quantization/basic_usage.py
+++ b/examples/quantization/basic_usage.py
@@ -50,6 +50,9 @@ def main():
     # load quantized model to the first GPU
     model = AutoGPTQForCausalLM.from_quantized(quantized_model_dir, device="cuda:0")
 
+    # load quantized model to CPU with QBits kernel linear.
+    model = AutoGPTQForCausalLM.from_quantized(quantized_model_dir, device="cpu")
+
     # download quantized model from Hugging Face Hub and load to the first GPU
     # model = AutoGPTQForCausalLM.from_quantized(repo_id, device="cuda:0", use_safetensors=True, use_triton=False)
 

--- a/tests/test_qbits_kernel.py
+++ b/tests/test_qbits_kernel.py
@@ -1,0 +1,152 @@
+import itertools
+import numpy as np
+import random
+import unittest
+
+import torch
+from torch import nn
+
+from auto_gptq.nn_modules.qlinear.qlinear_qbits import (
+    BITS_DTYPE_MAPPING,
+    QuantLinear,
+    convert_dtype_torch2str,
+    dequantize_weight,
+    unpack_to_8bit_signed
+)
+from intel_extension_for_transformers import qbits
+from parameterized import parameterized
+
+
+in_features = 256
+out_features = 128
+m = 16
+group_size = 32
+torch_dtype = torch.bfloat16 if qbits.check_isa_supported("AMX") else torch.float32
+
+BITS = (
+    4,
+    8,
+)
+SYM = (
+    True,
+    False
+)
+
+
+def gen_quant(k, n, bits, groupsize=-1, sym=False):
+    maxq = 2 ** bits - 1
+    w = torch.randn((k, n), dtype=torch_dtype, device="cpu")
+
+    original_w = w.clone()
+
+    if groupsize != -1:
+        w = w.reshape((-1, groupsize, n))
+        w = w.permute(1, 0, 2)
+        w = w.reshape((groupsize, -1))
+
+    if sym:
+        s = torch.max(torch.abs(w), 0, keepdim=True)[0]
+        s *= 2 / maxq
+        zeros = torch.full_like(s, (maxq + 1) // 2, dtype=torch.int32)
+    else:
+        xmax = w.max(0)[0]
+        xmin = w.min(0)[0]
+        range_width_channel = xmax - xmin
+        s = range_width_channel / maxq
+        # Compute the zero point
+        zeros = torch.round(-xmin / s).to(dtype=torch.int32)
+
+    # Quantize.
+    w = torch.round(w / s).int()
+
+    # Unsigned storage.
+    w += (maxq + 1) // 2
+    w = torch.clamp(w, 0, maxq)
+
+    # Dequantize.
+    ref = (w - zeros).to(dtype=torch_dtype) * s
+
+    if groupsize != -1:
+        def reshape(w):
+            w = w.reshape((groupsize, -1, n))
+            w = w.permute(1, 0, 2)
+            w = w.reshape((k, n)).contiguous()
+            return w
+        ref = reshape(ref)
+        w = reshape(w)
+    zeros = zeros.reshape((-1, n)).contiguous()
+
+    s = s.reshape((-1, n)).contiguous()
+    linear = nn.Linear(k, n, bias=False)
+    linear.weight.data = ref.t()
+
+    return original_w, linear, s, zeros
+
+
+class TestArcWeightOnly(unittest.TestCase):
+    @parameterized.expand(list(itertools.product(BITS, SYM)))
+    def test_quantization_4_cpu(self, bits, sym):
+        random.seed(10)
+        np.random.seed(10)
+        torch.random.manual_seed(10)
+        with torch.no_grad():
+            _, linear, scales, qzeros = gen_quant(in_features, out_features, bits, group_size, sym=sym)
+            qbits_linear = QuantLinear(bits=bits, group_size=group_size, infeatures=in_features, outfeatures=out_features, bias=False)
+            qbits_linear.pack(linear, scales.T, qzeros.T, g_idx=None)
+            fp_weight, _ = dequantize_weight(qbits_linear.qweight, qbits_linear.qzeros, qbits_linear.scales, bits)
+            intweight, zeros = unpack_to_8bit_signed(qbits_linear.qweight, qbits_linear.qzeros, bits)
+
+            if sym:
+                self.assertIsNone(zeros)
+            if zeros is None:
+                zeros = torch.empty(0, dtype=torch.int8)
+            else:
+                # change it to int8 with offset 128
+                if bits == 8:
+                    zeros = (zeros.to(torch.int32) - (2 ** (bits - 1))).to(torch.int8)
+                else:
+                    zeros -= (2**(bits - 1))
+                    zeros.bitwise_left_shift_(8 - bits)
+
+            if sym:
+                intweight -= (2**(bits - 1))
+            intweight = intweight.to(torch.int8 if sym else torch.uint8)
+            # due to asym return torch.uint8 but backend request int8,
+            # change it to int8 with offset 128
+            if not sym:
+                intweight = (intweight.to(torch.int32) - (2 ** (bits - 1))).to(torch.int8)
+
+            if bits == 4:
+                intweight.bitwise_left_shift_((8 - bits))
+
+            scales = scales if bits == 8 else scales / (2 ** (8 - bits))
+
+            g_idx = torch.empty(0, dtype=torch.int32)
+            qbits_qweight = qbits.repack_quantized_weight(intweight.contiguous(), scales.float(), zeros.contiguous(), g_idx,
+                                                          BITS_DTYPE_MAPPING[bits],  # weight_dtype
+                                                          "fp32",                    # scale_dtype
+                                                          convert_dtype_torch2str(torch_dtype),  #compute_dtype
+                                                          not sym,
+                                                          group_size)
+            qbits_out = torch.zeros(in_features, out_features, dtype=torch.float32)
+            qbits.dequantize_packed_weight(
+                qbits_qweight, qbits_out, False,
+                convert_dtype_torch2str(torch_dtype),
+                BITS_DTYPE_MAPPING[bits],
+                "fp32")
+            qbits_out = qbits_out.to(dtype=torch_dtype)
+            assert (torch.allclose(qbits_out, fp_weight, rtol=0.0001))
+
+            input = torch.rand(m, in_features, dtype=torch_dtype)
+            qbit_input = input.clone()
+            torch_out = torch.matmul(input, qbits_out)
+
+            qbits_dst = torch.zeros(m, out_features, dtype=torch_dtype)
+            qbits.woq_linear(
+                qbit_input.contiguous(), qbits_qweight, torch.empty(0), qbits_dst, convert_dtype_torch2str(torch_dtype), "int4_clip", "fp32", not sym)
+
+            print(abs((torch_out - qbits_dst)).max())
+            assert (torch.allclose(qbits_dst, torch_out, atol=0.005 if torch_dtype == torch.float32 else 0.25))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Based on the suggestion of https://github.com/AutoGPTQ/AutoGPTQ/issues/597, we have implemented the inference of GPTQ model on the CPU device. This PR will support Weight-Only quantization on CPU devices and infernce with QBbits backend. QBits backend has a 'bestla' kernel for CPU gemm op. And QBits is a module of [intel-extension-for-transformers](https://github.com/intel/intel-extension-for-transformers) package.