### PR TITLE
Fix transformers 4.38.0 seq_len

### DIFF
--- a/auto_gptq/nn_modules/fused_llama_attn.py
+++ b/auto_gptq/nn_modules/fused_llama_attn.py
@@ -73,7 +73,7 @@ class FusedLlamaAttentionForQuantizedModel(FusedBaseAttentionModule):
                 )
             kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
 
-        cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+        cos, sin = self.rotary_emb(value_states, position_ids=position_ids)
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
         # [bsz, nh, t, hd]
 


### PR DESCRIPTION
Quick fix. Only tested by making the same change in the installed pip package in combination with text-generation-webui. I didn't read the upstream changes.

- TypeError: LlamaRotaryEmbedding.forward() got an unexpected keyword argument 'seq_len'
BREAKING CHANGE: requires transformers >= 4.38.0