### PR TITLE
ADD ChatGLM model support

### DIFF
--- a/auto_gptq/modeling/__init__.py
+++ b/auto_gptq/modeling/__init__.py
@@ -6,6 +6,7 @@ from .codegen import CodeGenGPTQForCausalLM
 from .cohere import CohereGPTQForCausalLM
 from .decilm import DeciLMGPTQForCausalLM
 from .gemma import GemmaGPTQForCausalLM
+from .chatglm import ChatGLMForCausalLM
 from .gpt2 import GPT2GPTQForCausalLM
 from .gpt_bigcode import GPTBigCodeGPTQForCausalLM
 from .gpt_neox import GPTNeoXGPTQForCausalLM

--- a/auto_gptq/modeling/_const.py
+++ b/auto_gptq/modeling/_const.py
@@ -15,6 +15,7 @@ SUPPORTED_MODELS = [
     "moss",
     "gpt_bigcode",
     "codegen",
+    "chatglm",
     "RefinedWebModel",
     "RefinedWeb",
     "baichuan",

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -9,6 +9,7 @@ from .codegen import CodeGenGPTQForCausalLM
 from .cohere import CohereGPTQForCausalLM
 from .decilm import DeciLMGPTQForCausalLM
 from .gemma import GemmaGPTQForCausalLM
+from .chatglm import ChatGLMForCausalLM
 from .gpt2 import GPT2GPTQForCausalLM
 from .gpt_bigcode import GPTBigCodeGPTQForCausalLM
 from .gpt_neox import GPTNeoXGPTQForCausalLM
@@ -39,6 +40,7 @@ GPTQ_CAUSAL_LM_MODEL_MAP = {
     "llama": LlamaGPTQForCausalLM,
     "opt": OPTGPTQForCausalLM,
     "moss": MOSSGPTQForCausalLM,
+    "chatglm": ChatGLMForCausalLM,
     "gpt_bigcode": GPTBigCodeGPTQForCausalLM,
     "codegen": CodeGenGPTQForCausalLM,
     "cohere": CohereGPTQForCausalLM,

--- a/auto_gptq/modeling/chatglm.py
+++ b/auto_gptq/modeling/chatglm.py
@@ -1,0 +1,15 @@
+from ._base import BaseGPTQForCausalLM
+
+
+class ChatGLMForCausalLM(BaseGPTQForCausalLM):
+    layer_type = "GLMBlock"
+    layers_block_name = "transformer.encoder.layers"
+    outside_layer_modules = ["transformer.embedding.word_embeddings", "transformer.output_layer"]
+    inside_layer_modules = [
+        ["self_attention.query_key_value"],
+        ["self_attention.dense"],
+        ["mlp.dense_h_to_4h"],
+        ["mlp.dense_4h_to_h"],
+    ]
+
+__all__ = ["ChatGLMForCausalLM"]


### PR DESCRIPTION
Working with @Liurl26, we got ChatGLM support added to `autogpt`. 

However, need the following small patches/PRs applied to the `glm-4-9b` and  `glm-4-9b-chat` model codes. The model patches have been submitted to `chatglm` repo on HF. 


Base Model PR: https://huggingface.co/THUDM/glm-4-9b/discussions/4
Chat-Model PR: https://huggingface.co/THUDM/glm-4-9b-chat/discussions/28

GPTQ quants (tested):

https://huggingface.co/LnL-AI/glm-4-9b-gptq-4bit-qubitium-r1
https://huggingface.co/LnL-AI/glm-4-9b-chat-gptq-4bit-qubitium-r1

Please note ChatGLM has tendency to switch from English to Chinese in mid-reply or in direct reply to English prompt. This issue happens in both native and quantized model and needs further investigation outside the scope of this PR.

* [x] PASS autogptq inference of base model
* [x] PASS autogptq inference of chat model
* [x] PASS VLLM 0.4.3 inference of chat model  