### PR TITLE
Replace `"python"` with `sys.executable` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ if BUILD_CUDA_EXT:
         else:
             p = os.cpu_count()
         try:
-            subprocess.check_output(["python", "./autogptq_extension/qigen/generate.py", "--module", "--search", "--p", str(p)])
+            subprocess.check_output([sys.executable, "./autogptq_extension/qigen/generate.py", "--module", "--search", "--p", str(p)])
         except subprocess.CalledProcessError:
             raise Exception("Generating QiGen kernels failed with the error shown above.")
 


### PR DESCRIPTION
The `python` alias isn't guaranteed to exist(or have the necessary dependencies installed), so it's safer to use `sys.executable` to refer to the path of the current Python executable.