### PR TITLE
Fix error when loading quantized model with low_cpu_mem_usage is true

### DIFF
--- a/auto_gptq/modeling/_utils.py
+++ b/auto_gptq/modeling/_utils.py
@@ -518,7 +518,7 @@ def make_sure_no_tensor_in_meta_device(
 ):
     QuantLinear = dynamically_import_QuantLinear(use_triton, desc_act, group_size, bits=bits, disable_exllama=disable_exllama, disable_exllamav2=disable_exllamav2, use_marlin=use_marlin, use_tritonv2=use_tritonv2)
     for n, m in model.named_modules():
-        if isinstance(m, QuantLinear) and m.bias.device == torch.device("meta"):
+        if isinstance(m, QuantLinear) and m.bias is not None and m.bias.device == torch.device("meta"):
             m.register_buffer("bias", torch.zeros((m.outfeatures), dtype=torch.float16, device="cpu"))
 
 


### PR DESCRIPTION
Some models' QuantLinear doesn't have bias.
AutoGPTQForCausalLM.from_quantized will emit an error like:
```
Traceback (most recent call last):
  File "/home/mjc/qwen-gptq-load.py", line 6, in <module>
    model = AutoGPTQForCausalLM.from_quantized(
  File "/home/mjc/AutoGPTQ/auto_gptq/modeling/auto.py", line 146, in from_quantized
    return quant_func(
  File "/home/mjc/AutoGPTQ/auto_gptq/modeling/_base.py", line 966, in from_quantized
    make_sure_no_tensor_in_meta_device(
  File "/home/mjc/AutoGPTQ/auto_gptq/modeling/_utils.py", line 522, in make_sure_no_tensor_in_meta_device
    if isinstance(m, QuantLinear) and m.bias.device == torch.device("meta"):
AttributeError: 'NoneType' object has no attribute 'device'
```

So check it in make_sure_no_tensor_in_meta_device.