### PR TITLE
Work toward support of low-end devices.

### DIFF
--- a/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu
+++ b/autogptq_extension/cuda_256/autogptq_cuda_kernel_256.cu
@@ -4,6 +4,17 @@
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 
+// hfma2 on hardware with compute capability < 5.3
+// #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 530
+// __device__ half2 __hfma2(half2 a, half2 b, half2 c)
+// {
+//     return __floats2half2_rn(
+//         fmaf(__low2float(a), __low2float(b), __low2float(c)),
+//         fmaf(__high2float(a), __high2float(b), __high2float(c))
+//     );
+// }
+// #endif
+
 // atomicAdd for double-precision floating-point numbers on hardware with
 // compute capability < 6.0 from:
 // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomic-functions

--- a/autogptq_extension/cuda_64/autogptq_cuda_kernel_64.cu
+++ b/autogptq_extension/cuda_64/autogptq_cuda_kernel_64.cu
@@ -4,6 +4,17 @@
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 
+// hfma2 on hardware with compute capability < 5.3
+// #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 530
+// __device__ half2 __hfma2(half2 a, half2 b, half2 c)
+// {
+//     return __floats2half2_rn(
+//         fmaf(__low2float(a), __low2float(b), __low2float(c)),
+//         fmaf(__high2float(a), __high2float(b), __high2float(c))
+//     );
+// }
+// #endif
+
 // atomicAdd for double-precision floating-point numbers on hardware with
 // compute capability < 6.0 from:
 // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomic-functions

--- a/autogptq_extension/exllama/cu_compat.cuh
+++ b/autogptq_extension/exllama/cu_compat.cuh
@@ -48,7 +48,7 @@ __device__ __forceinline__ void atomicAdd_half2(half2* address, half2 val)
 
 __device__ __forceinline__ void atomicAdd(half* address, half val) { atomicAdd_half(address, val); }
 
-#if __CUDA_ARCH__ < 600 || defined(USE_ROCM)
+#if (__CUDA_ARCH__ < 600 && CUDA_VERSION < 12020) || defined(USE_ROCM)
 __device__ __forceinline__ void atomicAdd(half2* address, half2 val) { atomicAdd_half2(address, val); }
 #endif
 

--- a/autogptq_extension/exllama/matrix.cuh
+++ b/autogptq_extension/exllama/matrix.cuh
@@ -82,6 +82,23 @@ public:
 
 // TODO: Rewrite all these dot product functions using functors or something, move to q4_matmul.cu
 
+// hfma and hfma2 on hardware with compute capability < 5.3
+// #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 530
+// __device__ half __hfma(half a, half b, half c)
+// {
+//     return __float2half_rn(
+//         fmaf(__half2float(a), __half2float(b), __half2float(c))
+//     );
+// }
+// __device__ half2 __hfma2(half2 a, half2 b, half2 c)
+// {
+//     return __floats2half2_rn(
+//         fmaf(__low2float(a), __low2float(b), __low2float(c)),
+//         fmaf(__high2float(a), __high2float(b), __high2float(c))
+//     );
+// }
+// #endif
+
 // Accumulated dot product of 8-element row vectors in h and quantized column vectors in v, constant zero/scale
 
 __device__ __forceinline__ half2 dot_product_8

--- a/autogptq_extension/exllamav2/cuda/compat.cuh
+++ b/autogptq_extension/exllamav2/cuda/compat.cuh
@@ -46,7 +46,7 @@ __device__ __forceinline__ void atomicAdd_half2(half2* address, half2 val)
 
 __device__ __forceinline__ void atomicAdd(half* address, half val) { atomicAdd_half(address, val); }
 
-#if __CUDA_ARCH__ < 600 || defined(USE_ROCM)
+#if (__CUDA_ARCH__ < 600 && CUDA_VERSION < 12020) || defined(USE_ROCM)
 __device__ __forceinline__ void atomicAdd(half2* address, half2 val) { atomicAdd_half2(address, val); }
 #endif
 

--- a/autogptq_extension/exllamav2/cuda/quant/qdq_util.cuh
+++ b/autogptq_extension/exllamav2/cuda/quant/qdq_util.cuh
@@ -17,6 +17,17 @@ union half_uint16
     __device__ half_uint16(half val) : as_half(val) {}
 };
 
+// hfma2 on hardware with compute capability < 5.3
+// #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 530
+// __device__ half2 __hfma2(half2 a, half2 b, half2 c)
+// {
+//     return __floats2half2_rn(
+//         fmaf(__low2float(a), __low2float(b), __low2float(c)),
+//         fmaf(__high2float(a), __high2float(b), __high2float(c))
+//     );
+// }
+// #endif
+
 // Max_scale premultiplied by 1/256
 
 __forceinline__ __device__ half dq_scale(const int qs, const half max_scale)

--- a/autogptq_extension/marlin/marlin_cuda_kernel.cu
+++ b/autogptq_extension/marlin/marlin_cuda_kernel.cu
@@ -30,6 +30,17 @@ constexpr int ceildiv(int a, int b) {
   return (a + b - 1) / b;
 }
 
+// hfma2 on hardware with compute capability < 5.3
+// #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 530
+// __device__ half2 __hfma2(half2 a, half2 b, half2 c)
+// {
+//     return __floats2half2_rn(
+//         fmaf(__low2float(a), __low2float(b), __low2float(c)),
+//         fmaf(__high2float(a), __high2float(b), __high2float(c))
+//     );
+// }
+// #endif
+
 // Instances of `Vec` are used to organize groups of >>registers<<, as needed for instance as inputs to tensor core
 // operations. Consequently, all corresponding index accesses must be compile-time constants, which is why we
 // extensively use `#pragma unroll` throughout the kernel code to guarantee this.


### PR DESCRIPTION
I have a compute 50 device. To match exisitng code for compute 60 devices, I've added blocks of comments containing new draft implementations for half-precision fused-multiply-add, everywhere the __hfma functions are used.

I've also updated the include guards in exllama/cu_compat.cuh to reflect the presence of a half2 atomicAdd function for compute 60 devices in CUDA versions 12.2 and newer.

The code now builds for my compute_50 device if the commented function blocks are uncommented, although I lack the GPU RAM to run the testsuite on it.