### PR TITLE
Quickfix for failure after merged PR 731

### DIFF
--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -51,7 +51,7 @@ GPTQ_CAUSAL_LM_MODEL_MAP = {
     "internlm": InternLMGPTQForCausalLM,
     "qwen": QwenGPTQForCausalLM,
     "mistral": MistralGPTQForCausalLM,
-    "minicpm3":MiniCPM3ForCausalLM,
+    "minicpm3":MiniCPM3GPTQForCausalLM,
     "Yi": YiGPTQForCausalLM,
     "xverse": XverseGPTQForCausalLM,
     "deci": DeciLMGPTQForCausalLM,


### PR DESCRIPTION
Looks like https://github.com/AutoGPTQ/AutoGPTQ/pull/731 suffered from last-minute renames, and an error crept in which breaks loading `auto_gptq`.