### PR TITLE
add support for telechat2

### DIFF
--- a/auto_gptq/modeling/__init__.py
+++ b/auto_gptq/modeling/__init__.py
@@ -28,3 +28,4 @@ from .starcoder2 import Starcoder2GPTQForCausalLM
 from .xverse import XverseGPTQForCausalLM
 from .yi import YiGPTQForCausalLM
 from .minicpm3 import MiniCPM3GPTQForCausalLM
+from .telechat2 import TeleChat2GPTQForCausalLM

--- a/auto_gptq/modeling/_const.py
+++ b/auto_gptq/modeling/_const.py
@@ -25,7 +25,8 @@ SUPPORTED_MODELS = [
     "stablelm_epoch",
     "mpt",
     "cohere",
-    "minicpm3"
+    "minicpm3",
+    "telechat",
 ]
 if compare_transformers_version("v4.28.0", op="ge"):
     SUPPORTED_MODELS.append("llama")

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -30,6 +30,7 @@ from .starcoder2 import Starcoder2GPTQForCausalLM
 from .xverse import XverseGPTQForCausalLM
 from .yi import YiGPTQForCausalLM
 from .minicpm3 import MiniCPM3GPTQForCausalLM
+from .telechat2 import TeleChat2GPTQForCausalLM
 
 
 GPTQ_CAUSAL_LM_MODEL_MAP = {
@@ -63,6 +64,7 @@ GPTQ_CAUSAL_LM_MODEL_MAP = {
     "gemma2": Gemma2GPTQForCausalLM,
     "phi": PhiGPTQForCausalLM,
     "mpt": MPTGPTQForCausalLM,
+    "telechat": TeleChat2GPTQForCausalLM,
 }
 
 

--- a/auto_gptq/modeling/telechat2.py
+++ b/auto_gptq/modeling/telechat2.py
@@ -1,0 +1,20 @@
+from ._base import BaseGPTQForCausalLM
+
+
+class TeleChat2GPTQForCausalLM(BaseGPTQForCausalLM):
+    layer_type = "TelechatBlock"
+    layers_block_name = "transformer.h"
+    outside_layer_modules = ["transformer.word_embeddings", "transformer.ln_f"]
+
+    """
+    If other frameworks are used for inference (such as VLLM), 
+    it is best not to quantify QKV due to the organization of 
+    key value weights in the Telechat model
+    """   
+    inside_layer_modules = [
+        ["self_attention.dense"],
+        ["mlp.up_proj", "mlp.gate_proj"],
+        ["mlp.down_proj"]
+    ]
+
+__all__ = ["TeleChat2GPTQForCausalLM"]

--- a/auto_gptq/quantization/config.py
+++ b/auto_gptq/quantization/config.py
@@ -3,7 +3,7 @@ import logging
 import os
 from dataclasses import dataclass, field, fields
 from os.path import isdir, join
-from typing import Optional
+from typing import Optional, List
 
 import huggingface_hub
 from transformers.utils.hub import PushToHubMixin, cached_file
@@ -67,6 +67,7 @@ class BaseQuantizeConfig(PushToHubMixin):
     checkpoint_format: str = field(default=CHECKPOINT_FORMAT.GPTQ)
     model_name_or_path: Optional[str] = field(default=None)
     model_file_base_name: Optional[str] = field(default=None)
+    modules_to_not_convert: Optional[List[str]] = field(default=None)
 
     def __post_init__(self):
         fields_info = fields(self)
@@ -251,6 +252,7 @@ class BaseQuantizeConfig(PushToHubMixin):
             "true_sequential": self.true_sequential,
             "model_name_or_path": self.model_name_or_path,
             "model_file_base_name": self.model_file_base_name,
+            "modules_to_not_convert": self.modules_to_not_convert,
             QUANT_METHOD_FIELD: self.quant_method,
             CHECKPOINT_FORMAT_FIELD: self.checkpoint_format,
         }


### PR DESCRIPTION
Two minor changes:
1. Add support for the Telechat model (VLLM now supports the Telechat model).
2. Due to the lack of quantization in some layers of the Telechat model and in order to make the quantization method more flexible, we followed the approach of autoawq and added the modules_to_not_convert attribute to the config.